### PR TITLE
docker image auto-build-test-push cycle added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ localCheckout: &localCheckout
         command: docker tag oqs-curl $DOCKER_LOGIN/curl-generic && docker push $DOCKER_LOGIN/curl-generic && docker tag oqs-httpd-img $DOCKER_LOGIN/httpd-generic && docker push $DOCKER_LOGIN/httpd-generic && docker tag oqs-nginx-img $DOCKER_LOGIN/nginx-generic && docker push $DOCKER_LOGIN/nginx-generic
 
 
-# As of now (Mar 2020) CircleCI does not support building current OSX docker images... :-(
+# Reactivate when issue #13 is resolved:
 #.mac_job: &macjob
 #    macos:
 #       xcode: "11.3.0"
@@ -80,7 +80,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - debian-buster-amd64:
+      - ubuntu-bionic-x86_64:
           context: openquantumsafe
   nightly:
     triggers:
@@ -93,6 +93,6 @@ workflows:
     jobs:
 #      - macOS:   
 #          context: openquantumsafe
-      - ubuntu-bionic-x86_64:
+      - debian-buster-amd64:
           context: openquantumsafe
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,98 @@
+version: 2
+
+# CircleCI doesn't handle large file sets properly for local builds
+# https://github.com/CircleCI-Public/circleci-cli/issues/281#issuecomment-472808051
+localCheckout: &localCheckout
+  run: |-
+    PROJECT_PATH=$(cd ${CIRCLE_WORKING_DIRECTORY}; pwd)
+    mkdir -p ${PROJECT_PATH}
+    cd /tmp/_circleci_local_build_repo
+    git ls-files -z | xargs -0 -s 2090860 tar -c | tar -x -C ${PROJECT_PATH} 
+    cp -a /tmp/_circleci_local_build_repo/.git ${PROJECT_PATH}
+
+.linux_job: &linuxjob
+  docker:
+    - image: ${IMAGE}
+  steps:
+    - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
+    - setup_remote_docker
+    - run:
+        name: docker login
+        command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+    - run:
+        name: checkout dependencies
+        command: git clone --single-branch https://github.com/open-quantum-safe/liboqs.git tmp/liboqs && git clone --branch OQS-OpenSSL_1_1_1-stable --single-branch https://github.com/open-quantum-safe/openssl.git tmp/openssl
+    - run:
+        name: Curl
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build -t oqs-curl . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh || echo "Test complete")
+    - run: 
+        name: Apache httpd
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd httpd && docker build -t oqs-httpd-img . && docker run --detach --rm --name oqs-httpd oqs-httpd-img && sleep 2 && docker exec oqs-httpd bash -c 'echo  "GET /" | /opt/openssl/bin/openssl s_client -CAfile CA.crt -curves frodo640aes -crlf -connect localhost:4433')
+    - run: 
+        name: nginx
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd nginx && docker build -t oqs-nginx-img . && docker run --detach --rm --name oqs-nginx oqs-nginx-img && sleep 2 && docker exec oqs-nginx /opt/openssl/apps/openssl s_client -CAfile CA.crt -curves kyber512 -connect localhost:4433)
+    - run:
+        name: Push images
+        command: docker tag oqs-curl $DOCKER_LOGIN/curl-generic && docker push $DOCKER_LOGIN/curl-generic && docker tag oqs-httpd-img $DOCKER_LOGIN/httpd-generic && docker push $DOCKER_LOGIN/httpd-generic && docker tag oqs-nginx-img $DOCKER_LOGIN/nginx-generic && docker push $DOCKER_LOGIN/nginx-generic
+
+
+# As of now (Mar 2020) CircleCI does not support building current OSX docker images... :-(
+#.mac_job: &macjob
+#    macos:
+#       xcode: "11.3.0"
+#    steps:
+#        - checkout # change this from "checkout" to "*localCheckout" when running CircleCI locally
+#        - run:
+#            name: Install dependencies
+#            command: |
+#              .circleci/git_no_checkin_in_last_day.sh || (
+#              brew update &&
+#              brew cask install virtualbox &&
+#              brew install docker docker-machine &&
+#              docker-machine create default &&
+#              docker-machine ls &&
+#              docker-machine start &&
+#              docker-machine env default &&
+#              eval "$(docker-machine env default)" &&
+#              docker version &&
+#              brew unlink python@2 
+#              )
+#        - run:
+#            name: docker login
+#            command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
+#        - run:
+#            name: Curl
+#            command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build -t oqs-curl . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh)
+
+jobs:
+  debian-buster-amd64:
+    <<: *linuxjob
+    environment:
+      IMAGE: openquantumsafe/ci-debian-buster-amd64:latest
+  ubuntu-bionic-x86_64:
+    <<: *linuxjob
+    environment:
+      IMAGE: openquantumsafe/ci-ubuntu-bionic-x86_64:latest
+#  macOS:
+#    <<: *macjob
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - debian-buster-amd64:
+          context: openquantumsafe
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 4 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+#      - macOS:   
+#          context: openquantumsafe
+      - ubuntu-bionic-x86_64:
+          context: openquantumsafe
+

--- a/.circleci/git_no_checkin_in_last_day.sh
+++ b/.circleci/git_no_checkin_in_last_day.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Detects whether there has been a Git commit in the last day on this
+# branch. Returns 1 if there has been a commit, 0 if there has not.
+
+r=`git log --name-only --since="1 day ago" -n 2`
+if [ "x$r" == "x" ]; then 
+    echo "No oqs-demos commit in the last day. Checking liboqs now."
+    if [ -d tmp/liboqs ]; then
+            cd tmp/liboqs
+            r=`git log --name-only --since="1 day ago" -n 2`
+            if [ "x$r" == "x" ]; then 
+                echo "Also no liboqs commit in the last day. Now checking openssl."
+                if [ -d ../tmp/openssl ]; then
+            		cd ../tmp/openssl
+            		r=`git log --name-only --since="1 day ago" -n 2`
+            		if [ "x$r" == "x" ]; then 
+                		echo "Also no openssl commit in the last day. Build not necessary."
+                		exit 0
+            		else
+               			echo "openssl commit found. Should test."
+                		exit 1
+            		fi
+	
+    		else
+       			echo "Shouldn't happen (openssl not checked out?). Testing recommended."
+        		exit 1
+    		fi
+            else
+                echo "liboqs commit found. Should test."
+                exit 1
+            fi
+    else
+        echo "Shouldn't happen (liboqs not checked out?). Testing recommended."
+        exit 1
+    fi
+else
+    exit 1
+fi

--- a/.circleci/git_no_checkin_in_last_day.sh
+++ b/.circleci/git_no_checkin_in_last_day.sh
@@ -1,19 +1,21 @@
 #!/bin/bash
 
+set -e 
+
 # Detects whether there has been a Git commit in the last day on this
 # branch. Returns 1 if there has been a commit, 0 if there has not.
 
-r=`git log --name-only --since="1 day ago" -n 2`
+r=$(git log --name-only --since="1 second ago" -n 2)
 if [ "x$r" == "x" ]; then 
     echo "No oqs-demos commit in the last day. Checking liboqs now."
     if [ -d tmp/liboqs ]; then
             cd tmp/liboqs
-            r=`git log --name-only --since="1 day ago" -n 2`
+            r=$(git log --name-only --since="1 day ago" -n 2)
             if [ "x$r" == "x" ]; then 
                 echo "Also no liboqs commit in the last day. Now checking openssl."
                 if [ -d ../tmp/openssl ]; then
             		cd ../tmp/openssl
-            		r=`git log --name-only --since="1 day ago" -n 2`
+            		r=$(git log --name-only --since="1 day ago" -n 2)
             		if [ "x$r" == "x" ]; then 
                 		echo "Also no openssl commit in the last day. Build not necessary."
                 		exit 0

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@ oqs-demos
 ======================
 
 A repository of instructions (with associated patches and scripts) to enable, through [liboqs](https://github.com/open-quantum-safe/liboqs), the use of quantum-safe cryptography in various application software.
+
+In most cases, Dockerfiles encode the instructions for ease-of-use: Just do `docker build -t <package_name> .`. For more detailed usage instructions (parameters, algorithms, etc.) refer to the README for each package.
+
+Currently supported packages:
+
+- [Curl](curl)
+- [Apache httpd](httpd)
+- [nginx](nginx)
+- [Chromium](chromium) (Build instructions only)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-oqs-demos
+ oqs-demos
 ======================
 
 A repository of instructions (with associated patches and scripts) to enable, through [liboqs](https://github.com/open-quantum-safe/liboqs), the use of quantum-safe cryptography in various application software.


### PR DESCRIPTION
This adds CI testing to oqs-demos as well as automatic docker image creation on successful test completion. The latter only works if the CCI context `openquantumsafe` exists and is loaded with the environment variables DOCKER_LOGIN and DOCKER_PASSWORD. The latter can be a [docker hub access token](https://docs.docker.com/docker-hub/access-tokens). The images will be re-build whenever this repo,`liboqs/master`, or `openssl/OQS-OpenSSL_1_1_1-stable` change.