### PR TITLE
curl 7.69.1 with --curves parameter

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add build-base linux-headers \
             git docker wget
 
 # define the Curl version to be baked in
-ENV CURL_VERSION 7.66.0
+ENV CURL_VERSION 7.69.1
 
 # Default location where all binaries wind up:
 ARG INSTALLDIR=/opt/oqssa
@@ -28,6 +28,9 @@ WORKDIR /opt
 RUN git clone --single-branch --branch master https://github.com/open-quantum-safe/liboqs && \
     git clone --single-branch --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl ossl-src && \
     wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz && tar -zxvf curl-${CURL_VERSION}.tar.gz;
+
+# Add curl patchfile
+ADD patch-7.69.1.oqs.txt /opt/patch-7.69.1.oqs.txt
 
 # build liboqs shared and static
 WORKDIR /opt/liboqs
@@ -58,10 +61,14 @@ RUN set -x && \
 
 # build curl - injecting OQS CA generated above into root store
 WORKDIR /opt/curl-${CURL_VERSION}
+RUN patch -p1 < /opt/patch-7.69.1.oqs.txt
+
+# For curl debugging enable it by adding the line below to the configure command:
+#                    --enable-debug \
+
 RUN env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
         LDFLAGS=-Wl,-R${INSTALLDIR}/lib  \
         ./configure --prefix=${INSTALLDIR} \
-                    --enable-debug \
                     --with-ca-bundle=${INSTALLDIR}/bin/CA.crt \
                     --with-ssl=${INSTALLDIR} && \
     make -j && make install;

--- a/curl/README.md
+++ b/curl/README.md
@@ -5,13 +5,13 @@ This directory contains a Dockerfile that builds curl with the [OQS OpenSSL 1.1.
 1) Be sure to have [docker installed](https://docs.docker.com/install).
 2) Run `docker build -t oqs-curl .` to create a post quantum-enabled OpenSSL and Curl docker image
 3) To verify all components perform quantum-safe operations, first start the container with `docker run -it oqs-curl` thus starting an OQS-enabled TLS test server.
-4) On the command prompt in the docker container query that server using `curl https://localhost:4433`. If all works, the last command returns all TLS information documenting use of OQS-enabled TLS.
+4) On the command prompt in the docker container query that server using `curl --curves kyber512 https://localhost:4433`. If all works, the last command returns all TLS information documenting use of OQS-enabled TLS. The parameter to the `--curves` argument is the KEM_ALG chosen when building the docker container ('kyber512' by default).
 
 
 ## More details
 
 The Dockerfile 
-- obtains all source code required for building the quantum-safe crypto (QSC) algorithms, the QSC-enabled version of OpenSSL (v.1.1.1), curl (v.7.66.0) 
+- obtains all source code required for building the quantum-safe crypto (QSC) algorithms, the QSC-enabled version of OpenSSL (v.1.1.1), curl (v.7.69.1) 
 - builds all libraries and applications
 - creates OQS-enabled certificate files for a mini-root certificate authority (CA) 
 - creates an OQS-enabled server certificate for running a `localhost` QSC-TLS server
@@ -27,7 +27,7 @@ docker build -t oqs-curl --build-arg SIG_ALG=qteslapiii .
 Two further, runtime configuration option exist that can both be optionally set via docker environment variables:
 
 1) Setting the key exchange mechanism (KEM): By setting 'KEM_ALG' 
-to any of the [supported KEM algorithms built into OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange) one can run TLS using a KEM other than the default algorithm 'kyber512'. Example: `docker run -e KEM_ALG=newhope1024cca -it oqs-curl`. 
+to any of the [supported KEM algorithms built into OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange) one can run TLS using a KEM other than the default algorithm 'kyber512'. Example: `docker run -e KEM_ALG=newhope1024cca -it oqs-curl`. It is always necessary to also request use of this KEM algorithm by passing it to the invocation of `curl` with the `--curves` parameter, i.e. as such in the same example: `curl --curves newhope1024cca https://localhost:4433`.
 
 2) Setting the signature algorithm (SIG): By setting 'SIG_ALG' to any of the [supported OQS signature algorithms](https://github.com/open-quantum-safe/openssl#authentication) one can run TLS using a SIG other than the one set when building the image (see above). Example: `docker run -e SIG_ALG=picnicl1fs -it oqs-curl`.
 

--- a/curl/patch-7.69.1.oqs.txt
+++ b/curl/patch-7.69.1.oqs.txt
@@ -1,0 +1,182 @@
+--- curl-7.69.1/include/curl/curl.h
++++ curl-7.69.1-oqs/include/curl/curl.h
+@@ -1949,6 +1949,9 @@
+   /* allow RCPT TO command to fail for some recipients */
+   CURLOPT(CURLOPT_MAIL_RCPT_ALLLOWFAILS, CURLOPTTYPE_LONG, 290),
+ 
++  /* The (EC) curve [list] to select. */
++  CURLOPT(CURLOPT_CURVES, CURLOPTTYPE_STRINGPOINT, 291),
++
+   CURLOPT_LASTENTRY /* the last unused */
+ } CURLoption;
+ 
+--- curl-7.69.1/include/curl/typecheck-gcc.h
++++ curl-7.69.1-oqs/include/curl/typecheck-gcc.h
+@@ -256,6 +256,7 @@
+    (option) == CURLOPT_ACCEPT_ENCODING ||                                     \
+    (option) == CURLOPT_ALTSVC ||                                              \
+    (option) == CURLOPT_CAINFO ||                                              \
++   (option) == CURLOPT_CURVES ||                                              \
+    (option) == CURLOPT_CAPATH ||                                              \
+    (option) == CURLOPT_COOKIE ||                                              \
+    (option) == CURLOPT_COOKIEFILE ||                                          \
+--- curl-7.69.1/lib/doh.c
++++ curl-7.69.1-oqs/lib/doh.c
+@@ -331,6 +331,10 @@
+       ERROR_CHECK_SETOPT(CURLOPT_CAINFO,
+         data->set.str[STRING_SSL_CAFILE_ORIG]);
+     }
++    if(data->set.str[STRING_SSL_CURVES]) {
++      ERROR_CHECK_SETOPT(CURLOPT_CURVES,
++        data->set.str[STRING_SSL_CURVES]);
++    }
+     if(data->set.str[STRING_SSL_CAPATH_ORIG]) {
+       ERROR_CHECK_SETOPT(CURLOPT_CAPATH,
+         data->set.str[STRING_SSL_CAPATH_ORIG]);
+--- curl-7.69.1/lib/setopt.c
++++ curl-7.69.1-oqs/lib/setopt.c
+@@ -1904,6 +1904,14 @@
+     result = Curl_setstropt(&data->set.str[STRING_SSL_CAFILE_ORIG],
+                             va_arg(param, char *));
+     break;
++  case CURLOPT_CURVES:
++    /*
++     * Set accepted curves SSL connection setup.
++     * Specify colon-delimited list of curve algorithm names.
++     */
++    result = Curl_setstropt(&data->set.str[STRING_SSL_CURVES],
++                            va_arg(param, char *));
++    break;
+ #ifndef CURL_DISABLE_PROXY
+   case CURLOPT_PROXY_CAINFO:
+     /*
+--- curl-7.69.1/lib/url.c
++++ curl-7.69.1-oqs/lib/url.c
+@@ -3554,6 +3554,7 @@
+   data->set.ssl.primary.CApath = data->set.str[STRING_SSL_CAPATH_ORIG];
+   data->set.proxy_ssl.primary.CApath = data->set.str[STRING_SSL_CAPATH_PROXY];
+   data->set.ssl.primary.CAfile = data->set.str[STRING_SSL_CAFILE_ORIG];
++  data->set.ssl.primary.curves = data->set.str[STRING_SSL_CURVES];
+   data->set.proxy_ssl.primary.CAfile = data->set.str[STRING_SSL_CAFILE_PROXY];
+   data->set.ssl.primary.random_file = data->set.str[STRING_SSL_RANDOM_FILE];
+   data->set.proxy_ssl.primary.random_file =
+--- curl-7.69.1/lib/urldata.h
++++ curl-7.69.1-oqs/lib/urldata.h
+@@ -228,6 +228,7 @@
+   char *random_file;     /* path to file containing "random" data */
+   char *egdsocket;       /* path to file containing the EGD daemon socket */
+   char *cipher_list;     /* list of ciphers to use */
++  char *curves;          /* list of curves to use */
+   char *cipher_list13;   /* list of TLS 1.3 cipher suites to use */
+   char *pinned_key;
+   BIT(verifypeer);       /* set TRUE if this is desired */
+@@ -1581,6 +1582,7 @@
+   STRING_DNS_INTERFACE,
+   STRING_DNS_LOCAL_IP4,
+   STRING_DNS_LOCAL_IP6,
++  STRING_SSL_CURVES,
+ 
+   /* -- end of zero-terminated strings -- */
+ 
+--- curl-7.69.1/lib/vtls/openssl.c
++++ curl-7.69.1-oqs/lib/vtls/openssl.c
+@@ -2676,6 +2676,18 @@
+     infof(data, "Cipher selection: %s\n", ciphers);
+   }
+ 
++  {
++    char *curves = SSL_CONN_CONFIG(curves);
++    if(curves) {
++      if(!SSL_CTX_set1_curves_list(BACKEND->ctx, curves)) {
++        failf(data, "failed setting curves list: '%s'", curves);
++        return CURLE_SSL_CIPHER;
++      }
++    }
++  }
++
++
++
+ #ifdef HAVE_SSL_CTX_SET_CIPHERSUITES
+   {
+     char *ciphers13 = SSL_CONN_CONFIG(cipher_list13);
+--- curl-7.69.1/lib/vtls/vtls.c
++++ curl-7.69.1-oqs/lib/vtls/vtls.c
+@@ -117,6 +117,7 @@
+ 
+   CLONE_STRING(CApath);
+   CLONE_STRING(CAfile);
++  CLONE_STRING(curves);
+   CLONE_STRING(clientcert);
+   CLONE_STRING(random_file);
+   CLONE_STRING(egdsocket);
+@@ -131,6 +132,7 @@
+ {
+   Curl_safefree(sslc->CApath);
+   Curl_safefree(sslc->CAfile);
++  Curl_safefree(sslc->curves);
+   Curl_safefree(sslc->clientcert);
+   Curl_safefree(sslc->random_file);
+   Curl_safefree(sslc->egdsocket);
+--- curl-7.69.1/src/tool_cfgable.c
++++ curl-7.69.1-oqs/src/tool_cfgable.c
+@@ -112,6 +112,7 @@
+   Curl_safefree(config->cert_type);
+   Curl_safefree(config->proxy_cert_type);
+   Curl_safefree(config->cacert);
++  Curl_safefree(config->curves);
+   Curl_safefree(config->proxy_cacert);
+   Curl_safefree(config->capath);
+   Curl_safefree(config->proxy_capath);
+--- curl-7.69.1/src/tool_cfgable.h
++++ curl-7.69.1-oqs/src/tool_cfgable.h
+@@ -141,6 +141,7 @@
+   char *cert_type;
+   char *proxy_cert_type;
+   char *cacert;
++  char *curves;
+   char *proxy_cacert;
+   char *capath;
+   char *proxy_capath;
+--- curl-7.69.1/src/tool_getparam.c
++++ curl-7.69.1-oqs/src/tool_getparam.c
+@@ -270,6 +270,7 @@
+   {"EB", "socks5-gssapi",            ARG_BOOL},
+   {"EC", "etag-save",                ARG_FILENAME},
+   {"ED", "etag-compare",             ARG_FILENAME},
++  {"EE", "curves",                   ARG_STRING},
+   {"f",  "fail",                     ARG_BOOL},
+   {"fa", "fail-early",               ARG_BOOL},
+   {"fb", "styled-output",            ARG_BOOL},
+@@ -1712,6 +1713,10 @@
+ 
+       case 'D':
+         GetStr(&config->etag_compare_file, nextarg);
++        break;
++
++      case 'E':
++        GetStr(&config->curves, nextarg);
+         break;
+ 
+       default: /* unknown flag */
+--- curl-7.69.1/src/tool_help.c
++++ curl-7.69.1-oqs/src/tool_help.c
+@@ -61,6 +61,8 @@
+    "Use HTTP Basic Authentication"},
+   {"    --cacert <file>",
+    "CA certificate to verify peer against"},
++  {"    --curves <colon-separated-list of curves to select>",
++   "Curves to accept during session setup"},
+   {"    --capath <dir>",
+    "CA directory to verify peer against"},
+   {"-E, --cert <certificate[:password]>",
+--- curl-7.69.1/src/tool_operate.c
++++ curl-7.69.1-oqs/src/tool_operate.c
+@@ -1467,6 +1467,8 @@
+ 
+         if(config->cacert)
+           my_setopt_str(curl, CURLOPT_CAINFO, config->cacert);
++        if(config->curves)
++          my_setopt_str(curl, CURLOPT_CURVES, config->curves);
+         if(config->proxy_cacert)
+           my_setopt_str(curl, CURLOPT_PROXY_CAINFO, config->proxy_cacert);
+ 


### PR DESCRIPTION
Bumps curl version, implements #17 , creates workaround for https://github.com/open-quantum-safe/openssl/issues/172 