### PR TITLE
Generic build type fixed; build/usage documentation split

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,14 +26,17 @@ localCheckout: &localCheckout
         name: Curl
         command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build -t oqs-curl . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh || echo "Test complete")
     - run:
+        name: Curl generic (portable)
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build --build-arg LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF" -t oqs-curl-generic . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh || echo "Test complete")
+    - run:
         name: Apache httpd
         command: .circleci/git_no_checkin_in_last_day.sh || (cd httpd && docker build -t oqs-httpd-img . && docker run --detach --rm --name oqs-httpd oqs-httpd-img && sleep 2 && docker exec oqs-httpd bash -c 'echo  "GET /" | /opt/openssl/bin/openssl s_client -CAfile CA.crt -curves frodo640aes -crlf -connect localhost:4433')
     - run:
         name: nginx
         command: .circleci/git_no_checkin_in_last_day.sh || (cd nginx && docker build -t oqs-nginx-img . && docker run --detach --rm --name oqs-nginx oqs-nginx-img && sleep 2 && docker exec oqs-nginx /opt/openssl/apps/openssl s_client -CAfile CA.crt -curves kyber512 -connect localhost:4433)
     - run:
-        name: Push images
-        command: docker tag oqs-curl $TARGETNAME/curl-generic && docker push $TARGETNAME/curl-generic && docker tag oqs-httpd-img $TARGETNAME/httpd-generic && docker push $TARGETNAME/httpd-generic && docker tag oqs-nginx-img $TARGETNAME/nginx-generic && docker push $TARGETNAME/nginx-generic
+        name: Push all images
+        command: docker tag oqs-curl-generic $TARGETNAME/curl-generic && docker push $TARGETNAME/curl-generic && docker tag oqs-curl $TARGETNAME/curl && docker push $TARGETNAME/curl && docker tag oqs-httpd-img $TARGETNAME/httpd && docker push $TARGETNAME/httpd && docker tag oqs-nginx-img $TARGETNAME/nginx && docker push $TARGETNAME/nginx
 
 
 # Reactivate when issue #13 is resolved:

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -21,7 +21,7 @@ ENV CURL_VERSION 7.69.1
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build type variant
-ARG LIBOQS_BUILD_TYPE=Generic
+ARG LIBOQS_BUILD_DEFINES
 
 # get all sources
 WORKDIR /opt
@@ -34,7 +34,7 @@ ADD patch-7.69.1.oqs.txt /opt/patch-7.69.1.oqs.txt
 
 # build liboqs shared and static
 WORKDIR /opt/liboqs
-RUN mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=${LIBOQS_BUILD_TYPE} -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make && make install
+RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make && make install
 RUN mkdir build-static && cd build-static && cmake .. -DCMAKE_BUILD_TYPE=${LIBOQS_BUILD_TYPE} -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make && make install
 
 # build OQS-OpenSSL

--- a/curl/README.md
+++ b/curl/README.md
@@ -31,33 +31,16 @@ to any of the [supported KEM algorithms built into OQS-OpenSSL](https://github.c
 
 2) Setting the signature algorithm (SIG): By setting 'SIG_ALG' to any of the [supported OQS signature algorithms](https://github.com/open-quantum-safe/openssl#authentication) one can run TLS using a SIG other than the one set when building the image (see above). Example: `docker run -e SIG_ALG=picnicl1fs -it oqs-curl`.
 
-#### Build type argument
+#### Build type argument(s)
 
-The Dockerfile also facilitates building the underlying OQS library to different specifications (by setting the `--build-arg` variable `LIBOQS_BUILD_TYPE` to one of the following values):
-- "Debug" generates an image with full debugging information and without any optimizations
-- "Generic" creates an image with full compiler optimization but without any CPU feature optimization. This is the default setting.
-- Any other value creates an image with full optimizations, incl. utilization of all available CPU features.
+The Dockerfile also facilitates building the underlying OQS library to different specifications (by setting the `--build-arg` variable `LIBOQS_BUILD_DEFINES` as defined [here](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs).
 
-Use images build with the third option with care as they may not run on all platforms (e.g., on machines where CPU features are missing relative to the build machine).
-
-## Performance testing
-
-The docker image can also be used to execute TLS-level performance tests against the different OQS algoritms: Simply start 
+For example, with this build command
 ```
-docker run -it oqs-curl perftest.sh
-```
-to perform TLS handshakes for 200 seconds (TEST_TIME default value) using dilithium2 (SIG_ALG default value) and kyber512 (KEM_ALG default value) keys and certificates.
+docker build --build-arg LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF" -f Dockerfile -t oqs-curl-generic .
+``` 
+a generic system without processor-specific runtime optimizations is built, thus ensuring execution on all computers (at the cost of maximum runtime performance).
 
-A 'worked example' and more general alternative form of the command is
-```
-docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh
-```
-runs TLS handshakes for 5 seconds exercizing `picnicl1fs` and `sikep751`. Again, all [supported QSC algorithms](https://github.com/open-quantum-safe/openssl#supported-algorithms) can be set here.
+## Usage
 
-### "Classic"/non-QSC algorithm testing
-
-The following algorithm names may be set if one is interested in comparative performance measurements using "classic", i.e., non-QSC, crypto:
-
-- SIG_ALG: ed25519 ed448
-
-- KEM_ALG: X25519 P-384 P-256 P-521
+Information how to use the image is [available in the separate file USAGE.md](USAGE.md).

--- a/curl/USAGE.md
+++ b/curl/USAGE.md
@@ -1,0 +1,61 @@
+# OQS-curl
+
+This docker image contains a version of [curl](https://curl.haxx.se) build to also utilize quantum-safe crypto (QSC) operations.
+
+To this end, it contains [liboqs](https://github.com/open-quantum-safe/liboqs) as well as [OQS-OpenSSL](https://github.com/open-quantum-safe/openssl) from the [OpenQuantumSafe](https://openquantumsafe.org) project.
+
+As different images providing the same base functionality may be available, e.g., for debug or performance-optimized operations, the image name `oqs-curl` is consistently used in the description below. Be sure to adapt it to the image you want to use.
+
+## Quick start
+
+1) With `docker run -it oqs-curl` start an OQS-enabled TLS test server.
+2) On the command prompt in the docker container resulting from the first comment, one can query that server by issuing the command `curl --curves kyber512 https://localhost:4433`. 
+
+The latter command returns all TLS information documenting use of OQS-enabled TLS. The parameter to the `--curves` argument is [any Kex Exchange algorithm supported by OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange).
+
+## Retrieving data from other QSC-enabled TLS servers
+
+Beyond interacting with the built-in test server (utilizing `openssl s_server`) the image can also be used to retrieve data from any OQS-enabled TLS (1.3) server with the command `docker run -it oqs-curl curl <OQS-server URL>`.
+
+All standard `curl` parameters are available plus the option to explicitly request a specific OQS algorithm ("--curves") from the [supported KEX list](https://github.com/open-quantum-safe/openssl#key-exchange).
+
+
+## Performance testing
+
+The docker image can also be used to execute performance tests using the different algoritms supported: 
+
+
+### TLS handshake performance
+
+Simply start 
+```
+docker run -it oqs-curl perftest.sh
+```
+to perform TLS handshakes for 200 seconds (TEST_TIME default value) using dilithium2 (SIG_ALG default value) and kyber512 (KEM_ALG default value) keys and certificates.
+
+A 'worked example' and more general alternative form of the command is
+```
+docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh
+```
+runs TLS handshakes for 5 seconds exercizing `picnicl1fs` and `sikep751`. Again, all [supported QSC algorithms](https://github.com/open-quantum-safe/openssl#supported-algorithms) can be set here. Be sure to properly distinguish between SIGnature_ALGorithms and KEM(Key Exchange Mechanism)_ALGorithms.
+
+
+### Algorithm performance
+
+Simply start 
+```
+docker run -it oqs-curl openssl speed
+```
+to run through all crypto algorithms built into and enabled in the docker image. This includes classic as well as quantum-safe algorithms side by side.
+
+If interested in performance of only specific algorithms, this can be done by providing parameters as usual for [openssl speed](https://www.openssl.org/docs/man1.1.1/man1/openssl-speed.html). The list of [supported OQS algorithms is accessible here](https://github.com/open-quantum-safe/openssl#supported-algorithms), so an example call would be `docker run -it oqs-curl openssl speed -seconds 2 kyber90s512`.
+
+#### Classic algorithm names for reference
+
+The following algorithm names may be set if one is interested in comparative performance measurements using "classic", i.e., non-quantumsafe, crypto:
+
+- SIG_ALG: ed25519 ed448
+
+- KEM_ALG: X25519 P-384 P-256 P-521
+
+


### PR DESCRIPTION
Adapted building to the new cmake types / CPU features model. 
Until [RT handling](https://github.com/open-quantum-safe/liboqs/issues/624) is implemented, this now generates both an optimised and generic ("always running") docker image.
Also split out is usage information that could be linked as-is from docker hub, e.g., https://hub.docker.com/r/openquantumsafe/curl-generic -> USAGE.md

If this documentation approach is OK, the same will be done for httpd and nginx.