### PR TITLE
Size reduction

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,10 +30,10 @@ localCheckout: &localCheckout
         command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build --build-arg LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF" -t oqs-curl-generic . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh || echo "Test complete")
     - run:
         name: Apache httpd
-        command: .circleci/git_no_checkin_in_last_day.sh || (cd httpd && docker build -t oqs-httpd-img . && docker run --detach --rm --name oqs-httpd oqs-httpd-img && sleep 2 && docker exec oqs-httpd bash -c 'echo  "GET /" | /opt/openssl/bin/openssl s_client -CAfile CA.crt -curves frodo640aes -crlf -connect localhost:4433')
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd httpd && docker build -t oqs-httpd-img . && docker network create httpd-test && docker run --network httpd-test --detach --rm --name oqs-httpd oqs-httpd-img && sleep 2 && docker run --network httpd-test oqs-curl curl -k https://oqs-httpd:4433)
     - run:
         name: nginx
-        command: .circleci/git_no_checkin_in_last_day.sh || (cd nginx && docker build -t oqs-nginx-img . && docker run --detach --rm --name oqs-nginx oqs-nginx-img && sleep 2 && docker exec oqs-nginx /opt/openssl/apps/openssl s_client -CAfile CA.crt -curves kyber512 -connect localhost:4433)
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd nginx && docker build -t oqs-nginx-img . && docker network create nginx-test && docker run --network nginx-test --detach --rm --name oqs-nginx oqs-nginx-img && sleep 2 && docker run --network nginx-test oqs-curl-generic curl -k https://oqs-nginx:4433)
     - run:
         name: Push all images
         command: docker tag oqs-curl-generic $TARGETNAME/curl:latest && docker push $TARGETNAME/curl:latest && docker tag oqs-curl $TARGETNAME/curl:optimized && docker push $TARGETNAME/curl:optimized && docker tag oqs-httpd-img $TARGETNAME/httpd:latest && docker push $TARGETNAME/httpd:latest && docker tag oqs-nginx-img $TARGETNAME/nginx:latest && docker push $TARGETNAME/nginx:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ localCheckout: &localCheckout
         command: git clone --single-branch https://github.com/open-quantum-safe/liboqs.git tmp/liboqs && git clone --branch OQS-OpenSSL_1_1_1-stable --single-branch https://github.com/open-quantum-safe/openssl.git tmp/openssl
     - run:
         name: Curl
-        command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build -t oqs-curl . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh || echo "Test complete")
+        command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build -t oqs-curl . && docker run -e TEST_TIME=5 -e KEM_ALG=kyber768 -e SIG_ALG=dilithium3 -it oqs-curl perftest.sh || echo "Test complete")
     - run:
         name: Curl generic (portable)
         command: .circleci/git_no_checkin_in_last_day.sh || (cd curl && docker build --build-arg LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF" -t oqs-curl-generic . && docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1fs -it oqs-curl perftest.sh || echo "Test complete")
@@ -36,7 +36,7 @@ localCheckout: &localCheckout
         command: .circleci/git_no_checkin_in_last_day.sh || (cd nginx && docker build -t oqs-nginx-img . && docker run --detach --rm --name oqs-nginx oqs-nginx-img && sleep 2 && docker exec oqs-nginx /opt/openssl/apps/openssl s_client -CAfile CA.crt -curves kyber512 -connect localhost:4433)
     - run:
         name: Push all images
-        command: docker tag oqs-curl-generic $TARGETNAME/curl-generic && docker push $TARGETNAME/curl-generic && docker tag oqs-curl $TARGETNAME/curl && docker push $TARGETNAME/curl && docker tag oqs-httpd-img $TARGETNAME/httpd && docker push $TARGETNAME/httpd && docker tag oqs-nginx-img $TARGETNAME/nginx && docker push $TARGETNAME/nginx
+        command: docker tag oqs-curl-generic $TARGETNAME/curl:latest && docker push $TARGETNAME/curl:latest && docker tag oqs-curl $TARGETNAME/curl:optimized && docker push $TARGETNAME/curl:optimized && docker tag oqs-httpd-img $TARGETNAME/httpd:latest && docker push $TARGETNAME/httpd:latest && docker tag oqs-nginx-img $TARGETNAME/nginx:latest && docker push $TARGETNAME/nginx:latest
 
 
 # Reactivate when issue #13 is resolved:

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,6 +1,33 @@
 # Multi-stage build: First the full builder image:
 
+# define the Curl version to be baked in
+ARG CURL_VERSION=7.69.1
+
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
+
+# liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
+ARG LIBOQS_BUILD_DEFINES=
+
+# openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
+ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p256_kyber768:X25519:kyber768:newhope1024cca"
+
+# Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
+ARG SIG_ALG="dilithium2"
+
+# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
+ARG MAKE_DEFINES="-j 2"
+
+
 FROM alpine:3.11 as intermediate
+# Take in all global args
+ARG CURL_VERSION
+ARG INSTALLDIR
+ARG LIBOQS_BUILD_DEFINES
+ARG OPENSSL_BUILD_DEFINES
+ARG SIG_ALG
+ARG MAKE_DEFINES
+
 LABEL version="1"
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -14,15 +41,6 @@ RUN apk add build-base linux-headers \
             openssl openssl-dev \
             git docker wget
 
-# define the Curl version to be baked in
-ENV CURL_VERSION 7.69.1
-
-# Default location where all binaries wind up:
-ARG INSTALLDIR=/opt/oqssa
-
-# liboqs build type variant
-ARG LIBOQS_BUILD_DEFINES
-
 # get all sources
 WORKDIR /opt
 RUN git clone --single-branch --branch master https://github.com/open-quantum-safe/liboqs && \
@@ -30,19 +48,19 @@ RUN git clone --single-branch --branch master https://github.com/open-quantum-sa
     wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz && tar -zxvf curl-${CURL_VERSION}.tar.gz;
 
 # Add curl patchfile
-ADD patch-7.69.1.oqs.txt /opt/patch-7.69.1.oqs.txt
+ADD patch-${CURL_VERSION}.oqs.txt /opt/patch-${CURL_VERSION}.oqs.txt
 
 # build liboqs shared and static
 WORKDIR /opt/liboqs
-RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make && make install
-RUN mkdir build-static && cd build-static && cmake .. -DCMAKE_BUILD_TYPE=${LIBOQS_BUILD_TYPE} -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make && make install
+RUN mkdir build && cd build && cmake .. ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
+RUN mkdir build-static && cd build-static && cmake .. -DCMAKE_BUILD_TYPE=${LIBOQS_BUILD_TYPE} -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 
 # build OQS-OpenSSL
 WORKDIR /opt/ossl-src
 # curl looks for shared libraries
 # at ./configure time
-RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTALLDIR} && \
-    make && make install;
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared ${OPENSSL_BUILD_DEFINES} --prefix=${INSTALLDIR} && \
+    make ${MAKE_DEFINES} && make install;
 
 # set path to use 'new' openssl & curl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR}/bin:${PATH}"
@@ -51,9 +69,6 @@ ENV PATH="${INSTALLDIR}/bin:${PATH}"
 ENV OPENSSL=${INSTALLDIR}/bin/openssl
 ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
 
-# Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
-ARG SIG_ALG="dilithium2"
-
 WORKDIR ${INSTALLDIR}/bin
 RUN set -x && \
     # generate CA key and cert
@@ -61,7 +76,7 @@ RUN set -x && \
 
 # build curl - injecting OQS CA generated above into root store
 WORKDIR /opt/curl-${CURL_VERSION}
-RUN patch -p1 < /opt/patch-7.69.1.oqs.txt
+RUN patch -p1 < /opt/patch-${CURL_VERSION}.oqs.txt
 
 # For curl debugging enable it by adding the line below to the configure command:
 #                    --enable-debug \
@@ -71,7 +86,7 @@ RUN env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
         ./configure --prefix=${INSTALLDIR} \
                     --with-ca-bundle=${INSTALLDIR}/bin/CA.crt \
                     --with-ssl=${INSTALLDIR} && \
-    make && make install;
+    make ${MAKE_DEFINES} && make install;
 
 WORKDIR /
 
@@ -81,12 +96,9 @@ CMD ["serverstart.sh"]
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
 FROM alpine:3.11
-
-# Default root CA signature algorithm; can be set to any listed at https://github.com/open-quantum-safe/openssl#authentication
-ARG SIG_ALG="dilithium2"
-
-# Default location where all binaries wind up:
-ARG INSTALLDIR=/opt/oqssa
+# Take in all global args
+ARG INSTALLDIR
+ARG SIG_ALG
 
 # Only retain the ${INSTALLDIR} contents in the final image
 COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}
@@ -112,7 +124,8 @@ COPY serverstart.sh ${INSTALLDIR}/bin
 COPY perftest.sh ${INSTALLDIR}/bin
 
 # Enable a normal user to create new server keys off set CA
-RUN addgroup -S oqs && adduser -S oqs -G oqs && chown -R oqs.oqs /opt/test && chmod go+r ${INSTALLDIR}/bin/CA.key && chmod go+w ${INSTALLDIR}/bin/CA.srl
+RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs /opt/test && chmod go+r ${INSTALLDIR}/bin/CA.key && chmod go+w ${INSTALLDIR}/bin/CA.srl
 
 USER oqs
+STOPSIGNAL SIGTERM
 CMD ["serverstart.sh"]

--- a/curl/README.md
+++ b/curl/README.md
@@ -82,7 +82,7 @@ The default version set is known to work OK and depends on a patch. Therefore ch
 
 ### MAKE_DEFINES
 
-Allow setting parameters to `make` operation, e.g., '-j <i>' where i defines the number of jobs run in parallel during build.
+Allow setting parameters to `make` operation, e.g., '-j nnn' where nnn defines the number of jobs run in parallel during build.
 
 The default is conservative and known not to overload normal machines. If one has a very powerful (many cores, >64GB RAM) machine, passing larger numbers (or only '-j' for maximum parallelism) speeds up building considerably.
 

--- a/curl/README.md
+++ b/curl/README.md
@@ -44,3 +44,45 @@ a generic system without processor-specific runtime optimizations is built, thus
 ## Usage
 
 Information how to use the image is [available in the separate file USAGE.md](USAGE.md).
+
+## Build options
+
+The Dockerfile provided allows for significant customization of the image built:
+
+### LIBOQS_BUILD_DEFINES
+
+This permits changing the build options for the underlying library with the quantum safe algorithms. All possible options are documented [here](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs).
+
+By default, the image is built such as to have maximum portability regardless of CPU type and optimizations available, i.e. to run on the widest possible range of cloud machines.
+
+### OPENSSL_BUILD_DEFINES
+
+This permits changing the build options for the underlying openssl library containing the quantum safe algorithms. 
+
+The default setting defines a range of default algorithms suggested for key exchange. For more information see [the documentation](https://github.com/open-quantum-safe/openssl#default-algorithms-announced).
+
+### SIG_ALG
+
+This defines the quantum-safe cryptographic signature algorithm for the internally generated (demonstration) CA and server certificates.
+
+The default value is 'dilithium3' but can be set to any value documented [here](https://github.com/open-quantum-safe/openssl#authentication).
+
+
+### INSTALL_PATH
+
+This defines the resultant location of the software installatiion.
+
+By default this is '/opt/oqssa'. It is recommended to not change this. Also, all [usage documentation](USAGE.md) assumes this path.
+
+### CURL_VERSION
+
+This defines the curl software version to be build into the image.
+
+The default version set is known to work OK and depends on a patch. Therefore changing it is *not* recommended.
+
+### MAKE_DEFINES
+
+Allow setting parameters to `make` operation, e.g., '-j <i>' where i defines the number of jobs run in parallel during build.
+
+The default is conservative and known not to overload normal machines. If one has a very powerful (many cores, >64GB RAM) machine, passing larger numbers (or only '-j' for maximum parallelism) speeds up building considerably.
+

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -1,6 +1,33 @@
-FROM debian:buster-slim
+# Multi-stage build: First the full builder image:
 
-ENV HTTPD_VERSION 2.4.43
+# First: global build arguments: 
+
+# liboqs build type variant; build non-optimized by default (maximum portability of image):
+ARG LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF"
+
+# installation paths
+ARG OPENSSL_PATH=/opt/openssl
+ARG HTTPD_PATH=/opt/httpd
+
+# defines the QSC signature algorithm used for the certificates:
+ARG SIG_ALG="dilithium3"
+
+# define the httpd version to include
+ARG HTTPD_VERSION=2.4.43
+
+# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
+ARG MAKE_DEFINES="-j 2"
+
+
+FROM debian:buster-slim as intermediate
+# Take in global args
+ARG LIBOQS_BUILD_DEFINES
+ARG OPENSSL_PATH
+ARG HTTPD_PATH
+ARG SIG_ALG
+ARG HTTPD_VERSION
+ARG MAKE_DEFINES
+
 
 RUN apt-get update -qq \
     && apt-get install -y build-essential \
@@ -27,18 +54,18 @@ RUN git clone --single-branch --branch master https://github.com/open-quantum-sa
 
 # build liboqs (static linking only)
 WORKDIR /opt/liboqs
-RUN mkdir build-static && cd build-static && cmake ..  -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make && make install
+RUN mkdir build-static && cd build-static && cmake ..  -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/ossl-src/oqs && make ${MAKE_DEFINES} && make install
 
 # build OQS-OpenSSL
 WORKDIR /opt/ossl-src
-RUN ./config no-shared --prefix=/opt/openssl && \
-    make && make install_sw;
+RUN ./config no-shared --prefix=${OPENSSL_PATH} && \
+    make ${MAKE_DEFINES} && make install_sw;
 
 # build httpd
 WORKDIR /opt/httpd-${HTTPD_VERSION}
 RUN sed -i 's,-lcrypto,-lcrypto /opt/ossl-src/oqs/lib/liboqs.a -ldl,g' configure && \
     env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
-        ./configure --prefix=/opt/httpd \
+        ./configure --prefix=${HTTPD_PATH} \
                     --enable-debugger-mode \
                     --enable-ssl --with-ssl=/opt/openssl \
                     --enable-ssl-staticlib-deps \
@@ -48,29 +75,52 @@ RUN sed -i 's,-lcrypto,-lcrypto /opt/ossl-src/oqs/lib/liboqs.a -ldl,g' configure
     make && make install;
 
 # prepare to run httpd
-ARG OPENSSL=/opt/openssl/bin/openssl
 ARG OPENSSL_CNF=/opt/ossl-src/apps/openssl.cnf
 
 # Set a default QSC signature algorithm from the list at https://github.com/open-quantum-safe/openssl#authentication
 ARG SIG_ALG=dilithium2
 
-WORKDIR /opt/httpd
-COPY httpd.conf conf/httpd.conf
-COPY httpd-ssl.conf conf/extra/httpd-ssl.conf
+WORKDIR ${HTTPD_PATH}
 RUN set -x && \
+    mkdir pki && \
+    mkdir cacert && \
     # generate CA key and cert
-    ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} && \
+    ${OPENSSL_PATH}/bin/openssl req -x509 -new -newkey ${SIG_ALG} -keyout cacert/CA.key -out cacert/CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} && \
     # generate server CSR
-    ${OPENSSL} req -new -newkey ${SIG_ALG} -keyout conf/server.key -out server.csr -nodes -subj "/CN=httpd.demo.openquantumsafe.org" -config ${OPENSSL_CNF} && \
+    ${OPENSSL_PATH}/bin/openssl req -new -newkey ${SIG_ALG} -keyout pki/server.key -out pki/server.csr -nodes -subj "/CN=oqs-httpd" -config ${OPENSSL_CNF} && \
     # generate server cert
-    ${OPENSSL} x509 -req -in server.csr -out conf/server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
+    ${OPENSSL_PATH}/bin/openssl x509 -req -in pki/server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey cacert/CA.key -CAcreateserial -days 365;
+
+## second stage: Only create minimal image without build tooling and intermediate build results generated above:
+FROM debian:buster-slim 
+# Take in global args
+ARG HTTPD_PATH
+ARG OPENSSL_PATH
+
+RUN apt-get update -qq \
+    && apt-get install -y libapr1-dev libaprutil1-dev
+
+# Only retain the ${*_PATH} contents in the final image
+COPY --from=intermediate ${HTTPD_PATH} ${HTTPD_PATH}
+#COPY --from=intermediate ${OPENSSL_PATH}/apps/openssl ${OPENSSL_PATH}
+
+COPY httpd-conf/httpd-ssl.conf ${HTTPD_PATH}/httpd-conf/httpd-ssl.conf
+COPY httpd-conf/httpd.conf ${HTTPD_PATH}/httpd-conf/httpd.conf
+WORKDIR ${HTTPD_PATH}
 
 # forward request and error logs to docker log collector
-RUN ln -sf /dev/stdout /opt/httpd/logs/access_log && \
-    ln -sf /dev/stderr /opt/httpd/logs/error_log;
+RUN ln -sf /dev/stdout ${HTTPD_PATH}/logs/access_log && \
+    ln -sf /dev/stderr ${HTTPD_PATH}/logs/error_log;
+
+RUN addgroup --gid 1000 oqs && useradd -u 1000 -g 1000 oqs
+RUN chown -R oqs.oqs ${HTTPD_PATH}
+USER oqs
+
+# Ensure httpd just runs
+ENV PATH ${HTTPD_PATH}/bin:$PATH
 
 EXPOSE 4433
 
 STOPSIGNAL SIGTERM
 
-CMD ["/opt/httpd/bin/httpd", "-DFOREGROUND"]
+CMD ["httpd", "-f", "httpd-conf/httpd.conf", "-DFOREGROUND"]

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir build-static && cd build-static && cmake ..  -DBUILD_SHARED_LIBS=OFF -
 # build OQS-OpenSSL
 WORKDIR /opt/ossl-src
 RUN ./config no-shared --prefix=${OPENSSL_PATH} && \
-    make ${MAKE_DEFINES} && make install_sw;
+    make ${MAKE_DEFINES} && make install;
 
 # build httpd
 WORKDIR /opt/httpd-${HTTPD_VERSION}
@@ -67,29 +67,30 @@ RUN sed -i 's,-lcrypto,-lcrypto /opt/ossl-src/oqs/lib/liboqs.a -ldl,g' configure
     env CPPFLAGS="-I/opt/ossl-src/oqs/include" \
         ./configure --prefix=${HTTPD_PATH} \
                     --enable-debugger-mode \
-                    --enable-ssl --with-ssl=/opt/openssl \
+                    --enable-ssl --with-ssl=${OPENSSL_PATH} \
                     --enable-ssl-staticlib-deps \
                     --enable-mods-static=ssl && \
     # Append liboqs to the PROGRAM_LDADD variable definition in the generated Makefile
     sed -i 's,(LIBS),(LIBS) /opt/ossl-src/oqs/lib/liboqs.a,g' Makefile && \
-    make && make install;
+    make ${MAKE_DEFINES} && make install;
 
 # prepare to run httpd
-ARG OPENSSL_CNF=/opt/ossl-src/apps/openssl.cnf
+ARG OPENSSL_CNF=${OPENSSL_PATH}/ssl/openssl.cnf
 
 # Set a default QSC signature algorithm from the list at https://github.com/open-quantum-safe/openssl#authentication
 ARG SIG_ALG=dilithium2
 
 WORKDIR ${HTTPD_PATH}
+
+    # generate CA key and cert
+    # generate server CSR
+    # generate server cert
 RUN set -x && \
     mkdir pki && \
     mkdir cacert && \
-    # generate CA key and cert
     ${OPENSSL_PATH}/bin/openssl req -x509 -new -newkey ${SIG_ALG} -keyout cacert/CA.key -out cacert/CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} && \
-    # generate server CSR
     ${OPENSSL_PATH}/bin/openssl req -new -newkey ${SIG_ALG} -keyout pki/server.key -out pki/server.csr -nodes -subj "/CN=oqs-httpd" -config ${OPENSSL_CNF} && \
-    # generate server cert
-    ${OPENSSL_PATH}/bin/openssl x509 -req -in pki/server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey cacert/CA.key -CAcreateserial -days 365;
+    ${OPENSSL_PATH}/bin/openssl x509 -req -in pki/server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey cacert/CA.key -CAcreateserial -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
 FROM debian:buster-slim 

--- a/httpd/README.md
+++ b/httpd/README.md
@@ -47,7 +47,7 @@ The default version set is known to work OK but one could try any value availabl
 
 ### MAKE_DEFINES
 
-Allow setting parameters to `make` operation, e.g., '-j <i>' where i defines the number of jobs run in parallel during build.
+Allow setting parameters to `make` operation, e.g., '-j nnn' where nnn defines the number of jobs run in parallel during build.
 
 The default is conservative and known not to overload normal machines. If one has a very powerful (many cores, >64GB RAM) machine, passing larger numbers (or only '-j' for maximum parallelism) speeds up building considerably.
 

--- a/httpd/README.md
+++ b/httpd/README.md
@@ -9,36 +9,47 @@ This directory contains a Dockerfile that builds [httpd (a.k.a the Apache HTTP S
 1. `docker build --build-arg SIG_ALG=<SIG> --tag oqs-httpd-img .` (`<SIG>` can be any of the authentication algorithms listed [here](https://github.com/open-quantum-safe/openssl#authentication)). An alternative, simplified build instruction is `docker build -t oqs-httpd-img .`: This will generate the image with a default QSC algorithm (dilithium2 -- see Dockerfile to change this).
 2. `docker run --detach --rm --name oqs-httpd -p 4433:4433 oqs-httpd-img`
 
-This will start a docker container that has httpd listening for TLS 1.3 connections on port 4433. The following command can be used to verify that the httpd so built is capable of using quantum-safe cryptography:
-
-`docker exec oqs-httpd /opt/openssl/bin/openssl s_client -curves <KEX> -connect localhost:4433`
-
-where `<KEX>` can be any QSC key exchange algorithm listed in the configuration file `httpd-ssl.conf` in the `SSLOpenSSLConfCmd Curves` configuration section (a subset of all presently supported KEM algorithms as documented [here](https://github.com/open-quantum-safe/openssl#key-exchange) ).
-
-## Example
-
-This sequence
-
-```
-docker build -t oqs-httpd-img .
-docker run --detach --rm --name oqs-httpd -p 4433:4433 oqs-httpd-img
-docker exec oqs-httpd bash -c 'echo  "GET /" | /opt/openssl/bin/openssl s_client -CAfile CA.crt -curves frodo640aes -crlf -connect localhost:4433'
-```
-
-will
-
-- build a quantum-safe crypto (QSC)-enabled docker image of Apache httpd with a QSC root certificate embedded
-- start it serving TLS 1.3 connections protected with QSC signature algorithm Dilithium2 on port 4433
-- Query its default web page using the QSC KEX algorithm Frodo640AES
-
-*Note:* Leaving away reference to the root certificate file 'CA.crt' in the command above lets the `GET` command fail as the TLS connection can not be properly verified. Leaving away the option `-crlf` will also let the GET command fail as a security extension in Apache httpd requires CRLF command termination. You can check the nginx access logs via `docker logs oqs-httpd`.
-
-*Note 2:* Should you fail to see the actual web server contents in the `openssl s_client` output, you may want to add the option `-ign_eof` to the command to see it, i.e., `docker exec oqs-httpd bash -c 'echo  "GET /" | /opt/openssl/bin/openssl s_client -CAfile CA.crt -curves frodo640aes -crlf -connect localhost:4433 -ign_eof'`.
-
-## Further options
-
-`httpd.conf` and `httpd-ssl.conf` can be edited if a configuration other than the one used here is desired. In particular, the `SSLOpenConfCmd Curves` directive can be used to restrict the quantum-safe key-exchange algorithms that httpd supports. After changing the configuration, the `docker build -t oqs-httpd-img .` command has to be re-run of course.
+This will start a docker container that has httpd listening for TLS 1.3 connections on port 4433. 
 
 
-*Final Note:* You might want to delete the named test container at the end by running `docker rm -f oqs-httpd`.
+## Usage
+
+Complete information how to use the image is [available in the separate file USAGE.md](USAGE.md).
+
+## Build options
+
+The Dockerfile provided allows for significant customization of the image built:
+
+### LIBOQS_BUILD_DEFINES
+
+This permits changing the build options for the underlying library with the quantum safe algorithms. All possible options are documented [here](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs).
+
+By default, the image is built such as to have maximum portability regardless of CPU type and optimizations available, i.e. to run on the widest possible range of cloud machines.
+
+### SIG_ALG
+
+This defines the quantum-safe cryptographic signature algorithm for the internally generated (demonstration) CA and server certificates.
+
+The default value is 'dilithium3' but can be set to any value documented [here](https://github.com/open-quantum-safe/openssl#authentication).
+
+
+### HTTPD_PATH
+
+This defines the resultant location of the httpd installatiion.
+
+By default this is '/opt/httpd'. It is recommended to not change this. Also, all [usage documentation](USAGE.md) assumes this path.
+
+### HTTPD_VERSION
+
+This defines the apache httpd software version to be build into the image.
+
+The default version set is known to work OK but one could try any value available [for download](https://httpd.apache.org/download.cgi).
+
+### MAKE_DEFINES
+
+Allow setting parameters to `make` operation, e.g., '-j <i>' where i defines the number of jobs run in parallel during build.
+
+The default is conservative and known not to overload normal machines. If one has a very powerful (many cores, >64GB RAM) machine, passing larger numbers (or only '-j' for maximum parallelism) speeds up building considerably.
+
+
 

--- a/httpd/USAGE.md
+++ b/httpd/USAGE.md
@@ -1,0 +1,191 @@
+## Purpose 
+
+This is an [apache httpd](https://httpd.apache.org) docker image building on the [OQS OpenSSL 1.1.1 fork](https://github.com/open-quantum-safe/openssl), which allows httpd to negotiate quantum-safe keys and use quantum-safe authentication using TLS 1.3.
+
+If you built the docker image yourself following the instructions [here](https://github.com/open-quantum-safe/oqs-demos/tree/master/httpd), exchange the  name of the image from 'openquantumsafe/httpd' in the examples below suitably.
+
+This image has a built-in non-root user to permit execution without particular [docker privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) such as to allow installation in all types of Kubernetes clusters.
+
+## Quick start 
+
+Assuming Docker is [installed](https://docs.docker.com/install) the following command 
+
+```
+docker run -p 4433:4433 openquantumsafe/httpd
+```
+
+will start up the QSC-enabled httpd running and listening for quantum-safe crypto protected TLS 1.3 connections on port 4433.
+
+To retrieve a test page, a quantum-safe crypto client program is required. For the most simple use case, use the [docker image for curl](https://hub.docker.com/r/openquantumsafe/curl) with the required quantum-safe crypto enablement. 
+
+If you started the OQS-httpd image on a machine with a registered IP name the required command is simply
+
+```
+docker run -it openquantumsafe/curl curl -k https://<ip-name-of-testmachine>:4433
+```
+
+If you try this on your local computer, you need to execute both images within one docker network as follows:
+
+```
+docker network create httpd-test
+docker run --network httpd-test --name oqs-httpd -p 4433:4433 openquantumsafe/httpd
+docker run --network httpd-test -it openquantumsafe/curl curl -k https://oqs-httpd:4433
+```
+
+## Slightly more advanced usage options
+
+This httpd image supports all quantum-safe key exchange algorithms [presently supported by OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange). If you want to control with algorithm is actually used, you can request one from the list above to the curl command with the '--curves' parameter, e.g., requesting the hybrid Kyber768 variant:
+
+```
+docker run -it openquantumsafe/curl curl -k https://oqs-httpd:4433  --curves p256_kyber768
+```
+
+
+## Seriously more advanced usage options
+
+### httpd configuration
+
+If you want to adapt the docker image to your needs you may want to change the httpd configuration file. To facilitate this, you just need to mount your own 'httpd.conf' file into the image at the path `/opt/httpd/httpd-conf`. Assuming you stored your own file `httpd.conf` into a local folder named `httpd-conf` the required command would look like this:
+
+```
+docker run -p 4433:4433 -v `pwd`/httpd-conf:/opt/httpd/httpd-conf openquantumsafe/httpd
+```
+
+*Note*: Of particular interest is the parameter `SSLOpenSSLConfCmd Curves` as it can be used to set the (quantum safe) cryptographic algorithms supported by the httpd installation. See the example in the 'httpd.conf' built into the image and [accessible here](https://github.com/open-quantum-safe/oqs-demos/blob/master/httpd/httpd-conf/httpd.conf).
+
+### Logfile access
+
+The httpd logfiles are available in the docker-internal folder `/opt/httpd/logs`. Thus, if you want to look at them in the docker host, you can mount them into a local folder named 'httpd-logs' like this:
+
+```
+docker run -p 4433:4433 -v `pwd`/httpd-logs:/opt/httpd/logs openquantumsafe/httpd
+```
+
+### Validate server certificate
+
+If you look carefully at the curl command above, you will notice the option `-k` which turns off server certificate validation. In the quick start option, this is OK, but if you want to be sure that the set up can actually perform quantum-safe certificate validation, you need to retrieve the CA certificate pre-loaded into the httpd image in order to pass it to the curl command for validation. This is thus a two-step process:
+
+1) Extract CA certificate to local file 'CA.crt': `docker run -it openquantumsafe/httpd cat cacert/CA.crt > CA.crt`
+2) Make this certificate available to curl for verification
+
+```
+docker run -v `pwd`:/opt/cacert -it openquantumsafe/curl curl --cacert /opt/cacert/CA.crt https://<ip-name-of-testmachine>:4433
+```
+
+*Note*: This command will report a mismatch between the name of your machine and 'oqs-httpd', which is the name of the server built into the demo server certificate. Read below how to rectify this with your own server certificate.
+
+A completely successful call requires use of a local docker-network where the server name is ensured to match the one encoded in the certificate:
+
+```
+docker run --network httpd-test -v `pwd`:/opt/cacert -it openquantumsafe/curl curl --cacert /opt/cacert/CA.crt https://oqs-httpd:4433
+```
+
+## Completely standalone deployment
+
+For ease of demonstration, the OQS-httpd image comes with a server and CA certificate preloaded. For a real deployment, the installation of server-specific certificates is required. Also this can be facilitated by mounting your own server key and certificate into the image at the path '/opt/httpd/pki'. Again, assuming server certificate and key are placed in a local folder named `server-pki` the startup command would look like this:
+
+```
+docker run -p 4433:4433 -v `pwd`/server-pki:/opt/httpd/pki openquantumsafe/httpd
+```
+
+
+### Creating (test) CA and server certificates
+
+For creating the required keys and certificates, it is also possible to utilize the [openquantumsafe/curl](https://hub.docker.com/r/openquantumsafe/curl) image using standard `openssl` commands. 
+
+An example sequence is shown below, using 
+- 'qteslapi' for signing the CA certificate,
+- 'dilithium2' for signing the server certificate,
+- 'httpd.server.my.org' as the address of the server for which the certificate is intended.
+
+Instead of 'qteslapi' or 'dilithium2' any of the [quantum safe authentication algorithms presently supported](https://github.com/open-quantum-safe/openssl#authentication) can be used.
+
+```
+# create and enter directory to contain keys and certificates
+mkdir -p server-pki && cd server-pki
+
+# create CA key and certificate using qteslapi
+docker run -v `pwd`:/opt/tmp -it openquantumsafe/curl openssl req -x509 -new -newkey qteslapi -keyout /opt/tmp/CA.key -out /opt/tmp/CA.crt -nodes -subj "/CN=oqstest CA" -days 365
+
+# create server key using dilithium2
+docker run -v `pwd`:/opt/tmp -it openquantumsafe/curl openssl req -new -newkey dilithium2 -keyout /opt/tmp/server.key -out /opt/tmp/server.csr -nodes -subj "/CN=httpd.server.my.org"
+
+# create server certificate
+docker run -v `pwd`:/opt/tmp -it openquantumsafe/curl openssl x509 -req -in /opt/tmp/server.csr -out /opt/tmp/server.crt -CA /opt/tmp/CA.crt -CAkey /opt/tmp/CA.key -CAcreateserial -days 365
+```
+
+*Note*: You may want to leave away the `-nodes` option to the CA key generation command above to ensure the key is encrypted. You can then safe it for future use at another location.
+
+## Further options
+
+### openssl s_client
+
+You could also use the `openssl s_client` to connect to httpd if you want to follow the protocol more closely. A quantum-safe variant of this is also built-in to the [openquantumsafe/curl](https://hub.docker.com/r/openquantumsafe/curl) docker image. A possible invocation thus would be for example:
+
+```
+docker run --network httpd-test -it openquantumsafe/curl openssl s_client -connect oqs-httpd:4433
+```
+
+After successful session establishment, issue the command 'GET /' on the resultant command line to retrieve the contents of the httpd root page.
+
+For further options, refer to the [openssl s_client documentation](https://www.openssl.org/docs/man1.1.0/man1/openssl-s_client.html).
+
+*Note:* Should you fail to see the actual web server contents in the `openssl s_client` output, you may want to add the option `-ign_eof` to the command to see it, i.e., issue this command:
+
+```
+docker run --network httpd-test -it openquantumsafe/curl sh -c "echo 'GET /' | openssl s_client -connect oqs-httpd:4433 -ign_eof" 
+```
+
+
+### docker -name and --rm options
+
+To ease rapid startup and teardown, we strongly recommend using the docker [--name](https://docs.docker.com/engine/reference/commandline/run/#assign-name-and-allocate-pseudo-tty---name--it) and automatic removal option [--rm](https://docs.docker.com/engine/reference/commandline/run/).
+
+## List of specific configuration options at a glance
+
+### Port: 4433
+
+Port at which httpd listens by default for quantum-safe TLS connections. Defined/changeable in `httpd.conf`.
+
+### httpd logfile folder: /opt/httpd/logs
+
+### httpd configuration folder location: /opt/httpd/httpd-conf
+
+This folder contains two files: `httpd.conf` for baseline httpd configuration and `httpd-ssl.conf` for all TLS/SSL specific configuration options.
+
+### httpd PKI location: /opt/httpd/pki
+
+#### Server key: /opt/httpd/pki/server.key
+
+#### Server certificate: /opt/httpd/pki/server.crt
+
+## Putting it all together
+
+If you want to run your own, fully customized quantum safe httpd installation on your machine you can do this with this docker image by running this command (assuming you followed the instructions above for generating your own server keys and certificates).
+
+```
+# Ensure UID is properly set for all bind-mounted folders, e.g. like this
+rm -rf httpd-logs && mkdir httpd-logs
+
+# Start image with all config folders bind-mounted
+docker run --rm --name httpd.server.my.org \
+       -p 4433:4433 \
+       -v `pwd`/httpd-logs:/opt/httpd/logs \
+       -v `pwd`/server-pki:/opt/httpd/pki \
+       -v `pwd`/httpd-conf:/opt/httpd/httpd-conf \
+       openquantumsafe/httpd
+```
+
+Validating that all works as desired can be done by retrieving a document using server validation and this command:
+
+```
+# Give curl access to CA certificate via bind-mount
+docker run -v `pwd`/server-pki:/opt/tmp -it openquantumsafe/curl \
+           curl --cacert /opt/tmp/CA.crt https://httpd.server.my.org:4433
+```
+
+Again, if you don't have your own server and want to test on a local machine, start both of them in a docker network (adding the option `--network httpd-test`). 
+
+## Disclaimer
+
+[THIS IS NOT FIT FOR PRODUCTIVE USE](https://github.com/open-quantum-safe/openssl#limitations-and-security).

--- a/httpd/httpd-conf/httpd-ssl.conf
+++ b/httpd/httpd-conf/httpd-ssl.conf
@@ -52,10 +52,9 @@ Listen 4433
 SSLCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES
 SSLProxyCipherSuite HIGH:MEDIUM:!MD5:!RC4:!3DES
 
-# Select a subset of supported KEMs from https://github.com/open-quantum-safe/liboqs#supported-algorithms
+# You might want to select a subset of supported KEMs from https://github.com/open-quantum-safe/liboqs#supported-algorithms
 # Example:
-
-SSLOpenSSLConfCmd Curves oqs_kem_default:frodo640aes:frodo1344shake:kyber512:kyber768:kyber1024:newhope512cca:newhope1024cca:ntru_hps2048509:ntru_hps2048677:ntru_hrss701:lightsaber:saber:sidhp434:sidhp503:sikep751
+# SSLOpenSSLConfCmd Curves oqs_kem_default:frodo640aes:frodo1344shake:kyber512:kyber768:kyber1024:newhope512cca:newhope1024cca:ntru_hps2048509:ntru_hps2048677:ntru_hrss701:lightsaber:saber:sidhp434:sidhp503:sikep751
 
 #  By the end of 2016, only TLSv1.2 ciphers should remain in use.
 #  Older ciphers should be disallowed as soon as possible, while the
@@ -146,7 +145,7 @@ SSLEngine on
 #   Some ECC cipher suites (http://www.ietf.org/rfc/rfc4492.txt)
 #   require an ECC certificate which can also be configured in
 #   parallel.
-SSLCertificateFile "/opt/httpd/conf/server.crt"
+SSLCertificateFile "/opt/httpd/pki/server.crt"
 #SSLCertificateFile "/opt/httpd/conf/server-dsa.crt"
 #SSLCertificateFile "/opt/httpd/conf/server-ecc.crt"
 
@@ -156,7 +155,7 @@ SSLCertificateFile "/opt/httpd/conf/server.crt"
 #   you've both a RSA and a DSA private key you can configure
 #   both in parallel (to also allow the use of DSA ciphers, etc.)
 #   ECC keys, when in use, can also be configured in parallel
-SSLCertificateKeyFile "/opt/httpd/conf/server.key"
+SSLCertificateKeyFile "/opt/httpd/pki/server.key"
 #SSLCertificateKeyFile "/opt/httpd/conf/server-dsa.key"
 #SSLCertificateKeyFile "/opt/httpd/conf/server-ecc.key"
 

--- a/httpd/httpd-conf/httpd.conf
+++ b/httpd/httpd-conf/httpd.conf
@@ -49,7 +49,7 @@ ServerRoot "/opt/httpd"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
-Listen 80
+Listen 8080
 
 #
 # Dynamic Shared Object (DSO) Support
@@ -493,7 +493,7 @@ Include conf/extra/proxy-html.conf
 </IfModule>
 
 # Secure (SSL/TLS) connections
-Include conf/extra/httpd-ssl.conf
+Include httpd-conf/httpd-ssl.conf
 #
 # Note: The following must must be present to support
 #       starting without SSL on platforms with no /dev/random equivalent

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -72,15 +72,16 @@ RUN ./configure --prefix=${NGINX_PATH} \
     make ${MAKE_DEFINES} && make install;
 
 WORKDIR ${NGINX_PATH}
-RUN set -x && \
+
     # generate CA key and cert
+    # generate server CSR
+    # generate server cert
+RUN set -x && \
     mkdir cacert && \
     mkdir pki && \
     ${OPENSSL_PATH}/apps/openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out cacert/CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_PATH}/apps/openssl.cnf && \
-    # generate server CSR
     ${OPENSSL_PATH}/apps/openssl req -new -newkey ${SIG_ALG} -keyout pki/server.key -out server.csr -nodes -subj "/CN=oqs-nginx" -config ${OPENSSL_PATH}/apps/openssl.cnf && \
-    # generate server cert
-    ${OPENSSL_PATH}/apps/openssl x509 -req -in server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey CA.key -CAcreateserial -days 365;
+    ${OPENSSL_PATH}/apps/openssl x509 -req -in server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey CA.key -CAcreateserial -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
 FROM alpine 

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,22 +1,56 @@
-FROM debian:buster-slim
+# Multi-stage build: First the full builder image:
 
-ENV NGINX_VERSION 1.16.1
+# First: global build arguments: 
 
-RUN apt-get update -qq \
-    && apt-get install -y build-essential \
-                          git \
-                          # OQS
-                          autoconf \
-                          automake \
-			  cmake \
-                          libtool \
-                          libssl-dev \
-                          # nginx
-                          libpcre3-dev \
-                          # misc
-                          wget;
+# liboqs build type variant; build non-optimized by default (maximum portability of image):
+ARG LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF"
 
-# get sources
+# installation paths
+ARG OPENSSL_PATH=/opt/openssl
+ARG NGINX_PATH=/opt/nginx
+
+# defines the QSC signature algorithm used for the certificates:
+ARG SIG_ALG="dilithium3"
+
+# define the nginx version to include
+ARG NGINX_VERSION=1.16.1
+
+# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
+ARG MAKE_DEFINES="-j 2"
+
+
+FROM alpine as intermediate
+# Take in global args
+ARG LIBOQS_BUILD_DEFINES
+ARG OPENSSL_PATH
+ARG NGINX_PATH
+ARG SIG_ALG
+ARG NGINX_VERSION
+ARG MAKE_DEFINES
+
+
+# Get all software packages required for builing all components:
+RUN apk add build-base linux-headers \
+            libtool automake autoconf cmake \
+            make \
+            openssl openssl-dev \
+            git wget pcre-dev
+
+#RUN apt-get update -qq \
+#    && apt-get install -y build-essential \
+#                          git \
+#                          # OQS
+#                          autoconf \
+#                          automake \
+#			  cmake \
+#                          libtool \
+#                          libssl-dev \
+#                          # nginx
+#                          libpcre3-dev \
+#                          # misc
+#                          wget;
+#
+# get OQS sources
 WORKDIR /opt
 RUN git clone --single-branch --branch master https://github.com/open-quantum-safe/liboqs && \
     git clone --single-branch --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl && \
@@ -24,41 +58,62 @@ RUN git clone --single-branch --branch master https://github.com/open-quantum-sa
 
 # build liboqs (static only)
 WORKDIR /opt/liboqs
-RUN mkdir build-static && cd build-static && cmake ..  -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=/opt/openssl/oqs && make && make install
+RUN mkdir build-static && cd build-static && cmake ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${OPENSSL_PATH}/oqs .. && make ${MAKE_DEFINES} && make install
 
 # build nginx (which builds OQS-OpenSSL)
 WORKDIR /opt/nginx-${NGINX_VERSION}
-RUN ./configure --prefix=/opt/nginx \
+RUN ./configure --prefix=${NGINX_PATH} \
                 --with-debug \
-                --with-http_ssl_module --with-openssl=/opt/openssl \
+                --with-http_ssl_module --with-openssl=${OPENSSL_PATH} \
                 --without-http_gzip_module \
-                --with-cc-opt="-I/opt/openssl/oqs/include" \
+                --with-cc-opt=-I${OPENSSL_PATH}/oqs/include \
                 --with-ld-opt="-L/opt/openssl/oqs/lib" && \
     sed -i 's/libcrypto.a/libcrypto.a -loqs/g' objs/Makefile && \
-    make && make install;
+    make ${MAKE_DEFINES} && make install;
 
-# prepare to run nginx
-ARG OPENSSL=/opt/openssl/apps/openssl
-ARG OPENSSL_CNF=/opt/openssl/apps/openssl.cnf
-
-ARG SIG_ALG="dilithium2"
-
-WORKDIR /opt/nginx
-COPY nginx.conf conf/nginx.conf
+WORKDIR ${NGINX_PATH}
 RUN set -x && \
     # generate CA key and cert
-    ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF} && \
+    mkdir cacert && \
+    mkdir pki && \
+    ${OPENSSL_PATH}/apps/openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out cacert/CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_PATH}/apps/openssl.cnf && \
     # generate server CSR
-    ${OPENSSL} req -new -newkey ${SIG_ALG} -keyout server.key -out server.csr -nodes -subj "/CN=nginx.server.openquantumsafe.org" -config ${OPENSSL_CNF} && \
+    ${OPENSSL_PATH}/apps/openssl req -new -newkey ${SIG_ALG} -keyout pki/server.key -out server.csr -nodes -subj "/CN=oqs-nginx" -config ${OPENSSL_PATH}/apps/openssl.cnf && \
     # generate server cert
-    ${OPENSSL} x509 -req -in server.csr -out server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
+    ${OPENSSL_PATH}/apps/openssl x509 -req -in server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey CA.key -CAcreateserial -days 365;
+
+## second stage: Only create minimal image without build tooling and intermediate build results generated above:
+FROM alpine 
+# Take in global args
+ARG LIBOQS_BUILD_DEFINES
+ARG OPENSSL_PATH
+ARG NGINX_PATH
+ARG SIG_ALG
+
+RUN apk add pcre-dev
+
+# Only retain the ${*_PATH} contents in the final image
+COPY --from=intermediate ${NGINX_PATH} ${NGINX_PATH}
+#COPY --from=intermediate ${OPENSSL_PATH}/apps/openssl ${OPENSSL_PATH}
+COPY nginx-conf/ ${NGINX_PATH}/nginx-conf
+
+WORKDIR ${NGINX_PATH}
 
 # forward request and error logs to docker log collector
-RUN ln -sf /dev/stdout /opt/nginx/logs/access.log && \
-    ln -sf /dev/stderr /opt/nginx/logs/error.log;
+RUN ln -sf /dev/stdout ${NGINX_PATH}/logs/access.log && \
+    ln -sf /dev/stderr ${NGINX_PATH}/logs/error.log;
 
+# This expose command needs to be in line with what's spec'd in nginx.conf:
 EXPOSE 4433
+
+# Ensure nginx just runs
+ENV PATH ${NGINX_PATH}/sbin:$PATH
 
 STOPSIGNAL SIGTERM
 
-CMD ["/opt/nginx/sbin/nginx", "-g", "daemon off;"]
+# Enable a normal user to create new server keys off set CA
+RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs ${NGINX_PATH}
+USER oqs
+
+CMD ["nginx", "-c", "nginx-conf/nginx.conf", "-g", "daemon off;"]
+

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -44,6 +44,6 @@ The default version set is known to work OK but one could try any value availabl
 
 ### MAKE_DEFINES
 
-Allow setting parameters to `make` operation, e.g., '-j <i>' where i defines the number of jobs run in parallel during build.
+Allow setting parameters to `make` operation, e.g., '-j nnn' where nnn defines the number of jobs run in parallel during build.
 
 The default is conservative and known not to overload normal machines. If one has a very powerful (many cores, >64GB RAM) machine, passing larger numbers (or only '-j' for maximum parallelism) speeds up building considerably.

--- a/nginx/USAGE.md
+++ b/nginx/USAGE.md
@@ -1,0 +1,189 @@
+## Purpose 
+
+This is an [nginx](https://nginx.org) docker image building on the [OQS OpenSSL 1.1.1 fork](https://github.com/open-quantum-safe/openssl), which allows nginx to negotiate quantum-safe keys and use quantum-safe authentication using TLS 1.3.
+
+If you built the docker image yourself following the instructions [here](https://github.com/open-quantum-safe/oqs-demos/tree/master/nginx), exchange the name of the image from 'openquantumsafe/nginx' in the examples below suitably.
+
+This image has a built-in non-root user to permit execution without particular [docker privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) such as to allow installation in all types of Kubernetes clusters.
+
+## Quick start 
+
+Assuming Docker is [installed](https://docs.docker.com/install) the following command 
+
+```
+docker run -p 4433:4433 openquantumsafe/nginx
+```
+
+will start up the QSC-enabled nginx running and listening for quantum-safe crypto protected TLS 1.3 connections on port 4433.
+
+To retrieve a test page, a quantum-safe crypto client program is required. For the most simple use case, use the [docker image for curl](https://hub.docker.com/r/openquantumsafe/curl) with the required quantum-safe crypto enablement. 
+
+If you started the OQS-nginx image on a machine with a registered IP name the required command is simply
+
+```
+docker run -it openquantumsafe/curl curl -k https://<ip-name-of-testmachine>:4433
+```
+
+If you try this on your local computer, you need to execute both images within one docker network as follows:
+
+```
+docker network create nginx-test
+docker run --network nginx-test --name oqs-nginx -p 4433:4433 openquantumsafe/nginx
+docker run --network nginx-test -it openquantumsafe/curl curl -k https://oqs-nginx:4433
+```
+
+## Slightly more advanced usage options
+
+This nginx image supports all quantum-safe key exchange algorithms [presently supported by OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange). If you want to control with algorithm is actually used, you can request one from the list above to the curl command with the '--curves' parameter, e.g., requesting the hybrid Kyber768 variant:
+
+```
+docker run -it openquantumsafe/curl curl -k https://oqs-nginx:4433  --curves p256_kyber768
+```
+
+
+## Seriously more advanced usage options
+
+### nginx configuration
+
+If you want to adapt the docker image to your needs you may want to change the nginx configuration file. To facilitate this, you just need to mount your own 'nginx.conf' file into the image at the path `/opt/nginx/nginx-conf`. Assuming you stored your own file `nginx.conf` into a local folder named `nginx-conf` the required command would look like this:
+
+```
+docker run -p 4433:4433 -v `pwd`/nginx-conf:/opt/nginx/nginx-conf openquantumsafe/nginx
+```
+
+*Note*: Of particular interest is the parameter `ssl_ecdh_curve` as it can be used to set the (quantum safe) cryptographic algorithms supported by the nginx installation. See the example in the 'nginx.conf' built into the image and [accessible here](https://github.com/open-quantum-safe/oqs-demos/blob/master/nginx/nginx-conf/nginx.conf).
+
+### Logfile access
+
+The nginx logfiles are available in the docker-internal folder `/opt/nginx/logs`. Thus, if you want to look at them in the docker host, you can mount them into a local folder named 'nginx-logs' like this:
+
+```
+docker run -p 4433:4433 -v `pwd`/nginx-logs:/opt/nginx/logs openquantumsafe/nginx
+```
+
+### Validate server certificate
+
+If you look carefully at the curl command above, you will notice the option `-k` which turns off server certificate validation. In the quick start option, this is OK, but if you want to be sure that the set up can actually perform quantum-safe certificate validation, you need to retrieve the CA certificate pre-loaded into the nginx image in order to pass it to the curl command for validation. This is thus a two-step process:
+
+1) Extract CA certificate to local file 'CA.crt': `docker run -it openquantumsafe/nginx cat cacert/CA.crt > CA.crt`
+2) Make this certificate available to curl for verification
+
+```
+docker run -v `pwd`:/opt/cacert -it openquantumsafe/curl curl --cacert /opt/cacert/CA.crt https://<ip-name-of-testmachine>:4433
+```
+
+*Note*: This command will report a mismatch between the name of your machine and 'oqs-nginx', which is the name of the server built into the demo server certificate. Read below how to rectify this with your own server certificate.
+
+A completely successful call requires use of a local docker-network where the server name is ensured to match the one encoded in the certificate:
+
+```
+docker run --network nginx-test -v `pwd`:/opt/cacert -it openquantumsafe/curl curl --cacert /opt/cacert/CA.crt https://oqs-nginx:4433
+```
+
+## Completely standalone deployment
+
+For ease of demonstration, the OQS-nginx image comes with a server and CA certificate preloaded. For a real deployment, the installation of server-specific certificates is required. Also this can be facilitated by mounting your own server key and certificate into the image at the path '/opt/nginx/pki'. Again, assuming server certificate and key are placed in a local folder named `server-pki` the startup command would look like this:
+
+```
+docker run -p 4433:4433 -v `pwd`/server-pki:/opt/nginx/pki openquantumsafe/nginx
+```
+
+
+### Creating (test) CA and server certificates
+
+For creating the required keys and certificates, it is also possible to utilize the [openquantumsafe/curl](https://hub.docker.com/r/openquantumsafe/curl) image using standard `openssl` commands. 
+
+An example sequence is shown below, using 
+- 'qteslapi' for signing the CA certificate,
+- 'dilithium2' for signing the server certificate,
+- 'nginx.server.my.org' as the address of the server for which the certificate is intended.
+
+Instead of 'qteslapi' or 'dilithium2' any of the [quantum safe authentication algorithms presently supported](https://github.com/open-quantum-safe/openssl#authentication) can be used.
+
+```
+# create and enter directory to contain keys and certificates
+mkdir -p server-pki && cd server-pki
+
+# create CA key and certificate using qteslapi
+docker run -v `pwd`:/opt/tmp -it openquantumsafe/curl openssl req -x509 -new -newkey qteslapi -keyout /opt/tmp/CA.key -out /opt/tmp/CA.crt -nodes -subj "/CN=oqstest CA" -days 365
+
+# create server key using dilithium2
+docker run -v `pwd`:/opt/tmp -it openquantumsafe/curl openssl req -new -newkey dilithium2 -keyout /opt/tmp/server.key -out /opt/tmp/server.csr -nodes -subj "/CN=nginx.server.my.org"
+
+# create server certificate
+docker run -v `pwd`:/opt/tmp -it openquantumsafe/curl openssl x509 -req -in /opt/tmp/server.csr -out /opt/tmp/server.crt -CA /opt/tmp/CA.crt -CAkey /opt/tmp/CA.key -CAcreateserial -days 365
+```
+
+*Note*: You may want to leave away the `-nodes` option to the CA key generation command above to ensure the key is encrypted. You can then safe it for future use at another location.
+
+## Further options
+
+### openssl s_client
+
+You could also use the `openssl s_client` to connect to nginx if you want to follow the protocol more closely. A quantum-safe variant of this is also built-in to the [openquantumsafe/curl](https://hub.docker.com/r/openquantumsafe/curl) docker image. A possible invocation thus would be for example:
+
+```
+docker run --network nginx-test -it openquantumsafe/curl openssl s_client -connect oqs-nginx:4433
+```
+
+After successful session establishment, issue the command 'GET /' on the resultant command line to retrieve the contents of the nginx root page.
+
+For further options, refer to the [openssl s_client documentation](https://www.openssl.org/docs/man1.1.0/man1/openssl-s_client.html).
+
+*Note:* Should you fail to see the actual web server contents in the `openssl s_client` output, you may want to add the option `-ign_eof` to the command to see it, i.e., issue this command:
+
+```
+docker run --network nginx-test -it openquantumsafe/curl sh -c "echo 'GET /' | openssl s_client -connect oqs-nginx:4433 -ign_eof" 
+```
+
+
+### docker -name and --rm options
+
+To ease rapid startup and teardown, we strongly recommend using the docker [--name](https://docs.docker.com/engine/reference/commandline/run/#assign-name-and-allocate-pseudo-tty---name--it) and automatic removal option via [--rm](https://docs.docker.com/engine/reference/commandline/run/).
+
+## List of specific configuration options at a glance
+
+### Port: 4433
+
+Port at which nginx listens by default for quantum-safe TLS connections. Defined/changeable in `nginx.conf`.
+
+### nginx logfile folder: /opt/nginx/logs
+
+### nginx configuration file location: /opt/nginx/nginx-conf/nginx.conf
+
+### nginx PKI location: /opt/nginx/pki
+
+#### Server key: /opt/nginx/pki/server.key
+
+#### Server certificate: /opt/nginx/pki/server.crt
+
+## Putting it all together
+
+If you want to run your own, fully customized quantum safe nginx installation on your machine you can do this with this docker image by running this command (assuming you followed the instructions above for generating your own server keys and certificates).
+
+```
+# Ensure UID is properly set for all bind-mounted folders, e.g. like this
+rm -rf nginx-logs && mkdir nginx-logs
+
+# Start image with all config folders bind-mounted
+docker run --rm --name nginx.server.my.org \
+       -p 4433:4433 \
+       -v `pwd`/nginx-logs:/opt/nginx/logs \
+       -v `pwd`/server-pki:/opt/nginx/pki \
+       -v `pwd`/nginx-conf:/opt/nginx/nginx-conf \
+       openquantumsafe/nginx
+```
+
+Validating that all works as desired can be done by retrieving a document using server validation and this command:
+
+```
+# Give curl access to CA certificate via bind-mount
+docker run -v `pwd`/server-pki:/opt/tmp -it openquantumsafe/curl \
+           curl --cacert /opt/tmp/CA.crt https://nginx.server.my.org:4433
+```
+
+Again, if you don't have your own server and want to test on a local machine, start both of them in a docker network (adding the option `--network nginx-test`). 
+
+## Disclaimer
+
+[THIS IS NOT FIT FOR PRODUCTIVE USE](https://github.com/open-quantum-safe/openssl#limitations-and-security).

--- a/nginx/nginx-conf/nginx.conf
+++ b/nginx/nginx-conf/nginx.conf
@@ -11,7 +11,7 @@ events {
 
 
 http {
-    include       mime.types;
+    include       ../conf/mime.types;
     default_type  application/octet-stream;
 
     #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -28,8 +28,9 @@ http {
 
     #gzip  on;
 
+    # also start up plain server for test purposes but do not expose by default in docker image
     server {
-        listen       80;
+        listen       8080;
         server_name  localhost;
 
         #charset koi8-r;
@@ -92,21 +93,21 @@ http {
     # HTTPS server
     #
     server {
-        listen       127.0.0.1:4433 ssl;
+        listen       0.0.0.0:4433 ssl;
 
         access_log  /opt/nginx/logs/access.log;
         error_log   /opt/nginx/logs/error.log;
         
-        ssl_certificate      /opt/nginx/server.crt;
-        ssl_certificate_key  /opt/nginx/server.key;
+        ssl_certificate      /opt/nginx/pki/server.crt;
+        ssl_certificate_key  /opt/nginx/pki/server.key;
 
         ssl_session_cache    shared:SSL:1m;
         ssl_session_timeout  5m;
 
         ssl_protocols TLSv1.3;
-	# Select a subset of supported KEMs from https://github.com/open-quantum-safe/liboqs#supported-algorithms
-	# Example:
-        ssl_ecdh_curve oqs_kem_default:frodo976shake:frodo1344shake:kyber512:kyber768:kyber1024:newhope512cca:newhope1024cca:ntru_hps2048509:ntru_hps2048677:ntru_hrss701:lightsaber:saber:sidhp434:sidhp503:sikep751;
+	# You could select a subset of supported KEMs from https://github.com/open-quantum-safe/liboqs#supported-algorithms
+	# Example (longer strings not supported by nginx!):
+        # ssl_ecdh_curve oqs_kem_default:frodo976shake:frodo1344shake:p256_kyber512:kyber768:kyber1024:newhope512cca:newhope1024cca:ntru_hps2048509:ntru_hps2048677:ntru_hrss701:lightsaber:saber:sidhp503:sikep751:kyber90s512:X25519;
 
         location / {
             root   html;


### PR DESCRIPTION
- Image sizes reduced for httpd (>4GB to 296MB) and nginx (>3GB to 77MB)
- Documentation split between README (built) and USAGE (also at docker hub: https://hub.docker.com/u/openquantumsafe)
- Configuration options extended and documented
- Tests updated
- (non-portable) Optimised variant only build for curl and tagged ':optimised' (same docker hub location)
- generic/portable version tagged ':latest'

CCI tests ran OK at: https://circleci.com/gh/baentsch/oqs-software/107 