### PR TITLE
Updated Chromium instructions.

### DIFF
--- a/chromium/BUILD.gn.patch
+++ b/chromium/BUILD.gn.patch
@@ -1,8 +1,8 @@
 diff --git a/third_party/boringssl/BUILD.gn b/third_party/boringssl/BUILD.gn
-index 250ed85424..48314a7d64 100644
+index b435499f459b..0493ba2ec628 100644
 --- a/third_party/boringssl/BUILD.gn
 +++ b/third_party/boringssl/BUILD.gn
-@@ -12,7 +12,7 @@ import("BUILD.generated_tests.gni")
+@@ -13,7 +13,7 @@ import("BUILD.generated_tests.gni")
  
  # Config for us and everybody else depending on BoringSSL.
  config("external_config") {
@@ -11,7 +11,7 @@ index 250ed85424..48314a7d64 100644
    if (is_component_build) {
      defines = [ "BORINGSSL_SHARED_LIBRARY" ]
    }
-@@ -44,7 +44,7 @@ config("no_asm_config") {
+@@ -45,7 +45,7 @@ config("no_asm_config") {
  }
  
  all_sources = crypto_sources + ssl_sources
@@ -20,11 +20,11 @@ index 250ed85424..48314a7d64 100644
  
  # Windows' assembly is built with NASM. The other platforms use the platform
  # assembler. Exclude Windows ARM64 because NASM targets x86 and x64 only.
-@@ -113,6 +113,7 @@ component("boringssl") {
+@@ -111,6 +111,7 @@ component("boringssl") {
    sources = all_sources
    public = all_headers
    friend = [ ":*" ]
 +  libs = ["//third_party/boringssl/src/oqs/lib/liboqs.a"]
-   deps = [
-     "//third_party/boringssl/src/third_party/fiat:fiat_license",
-   ]
+   deps = [ "//third_party/boringssl/src/third_party/fiat:fiat_license" ]
+ 
+   # Mark boringssl_asm as a public dependency so the OPENSSL_NO_ASM

--- a/chromium/README.md
+++ b/chromium/README.md
@@ -1,12 +1,10 @@
-This directory contains instructions and corresponding patches to build the Chromium web browser using the [OQS BoringSSL fork](https://github.com/open-quantum-safe/boringssl), thereby enabling Chromium to use the quantum-safe key exchange algorithms provided by liboqs.
-
-The fork, and by extension Chromium, at present only support the use of quantum-safe key exchange algorithms in TLS 1.3. Furthermore, the instructions have only been tested on an Ubuntu 19.04 x86_64 machine.
+This directory contains instructions and corresponding patches to build the Chromium web browser using the [OQS-BoringSSL fork](https://github.com/open-quantum-safe/boringssl), thereby enabling Chromium to use quantum-safe key exchange algorithms. Note that these instructions have only been tested on an Ubuntu 19.10 x86_64 machine and apply at present only to a select subset of quantum-safe key-exchanges.
 
 0. Ensure the system requirements listed [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#System-requirements) are met.
 
-1. To obtain the source code, follow the instructions in the "Install depot_tools" and "Get the code" sections [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#Install). Be sure to obtain the entire repository history, as we will checkout a specific commit.
+1. To obtain the source code, follow the instructions in the "Install depot_tools" and "Get the code" sections [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#Install).
 
-2. Navigate to the root directory of the source code, which we will refer to hereafter as `<CHROMIMUM_ROOT>`, and run `git checkout 6d326b9edbf4c2ee1c3ad155d16012acf3c0cc0c`, which is the latest commit for which we have verified the build instructions. Then, to ensure that all of chromium's third party dependencies are compatible with this commit, run `gclient sync -D --with_branch_heads --with_tags`.
+2. Navigate to the root directory of the source code, which we will refer to hereafter as `<CHROMIMUM_ROOT>`, and run `git checkout 85.0.4161.2`, which is the latest tag for which we have verified the build instructions. Then, to ensure that all of chromium's third party dependencies are compatible with this tag, run `gclient sync`.
 
 3. Navigate to `<CHROMIUM_ROOT>/third_party/boringssl/src`, and switch the BoringSSL source code to the OQS-BoringSSL fork by running the following commands:
 
@@ -17,16 +15,17 @@ The fork, and by extension Chromium, at present only support the use of quantum-
 4. In a directory of your choosing, clone and build liboqs as follows:
 
 - `git clone --branch master https://github.com/open-quantum-safe/liboqs.git`
-- `cd liboqs && autoreconf -i`
-- `./configure --prefix=<CHROMIUM_ROOT>/third_party/boringssl/src/oqs --without-openssl --enable-shared=no`
-- `make -j && make install`
+- `cd liboqs && mkdir build && cd build`
+- `cmake .. -G"Ninja" -DCMAKE_INSTALL_PREFIX=<CHROMIUM_ROOT>/third_party/boringssl/src/oqs -DOQS_USE_OPENSSL=OFF`
+- `ninja && ninja install`
 
-5. Now, navigate to `<CHROMIUM_ROOT>` and apply the `build.gn.patch` file provided here by running `git apply <PATH_TO_PATCH_FILE>`. Then, navigate to `thid_party/boringssl`, and run `python src/util/generate_build_files.py gn`.
+5. Now, navigate to `<CHROMIUM_ROOT>` and apply the `BUILD.gn.patch` file provided here by running `git apply <PATH_TO_PATCH_FILE>`. Then, navigate to `thid_party/boringssl`, and run `python src/util/generate_build_files.py gn`.
 
-6. Finally, follow the instructions [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#Install-additional-build-dependencies) from the "Install additional build dependencies" section onwards to build and run Chromium.
+6. Finally, follow the instructions [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#Install-additional-build-dependencies) from the "Install additional build dependencies" section onwards to build Chromium.
 
-To verify that Chromium can perform a TLS 1.3 handshake using a post-quantum key exchange:
+To verify that Chromium can perform a TLS 1.3 handshake using a post-quantum key exchange and authentication algorithm:
 
+0. Navigate to `<CHROMIUM_ROOT>`, and start Chromium by executing `./out/Default/chrome --ignore-certificate-errors`
 1. Navigate again to the `<CHROMIUM_ROOT>/third_party/boringssl/src` folder, and build OQS-BoringSSL as a standalone project by following the instructions in that directory's `README.md` file.
-2. Then, in the `build` directory, run `./tool/bssl server -curves oqs_<KEX> -accept localhost:4433`, where `<KEX>` is any key-exchange algorithm listed [here](https://github.com/open-quantum-safe/boringssl#supported-algorithms).
-3. In the Chromium browser, load `https://localhost:4433`.
+2. Then, in the `build` directory, run `./tool/bssl server -accept 4433 -www -loop -curves <KEX>`, where `<KEX>` can be any key-exchange algorithm that are both listed [here](https://github.com/open-quantum-safe/boringssl#supported-algorithms) and are listed in the array [here](https://github.com/open-quantum-safe/boringssl/blob/master/ssl/t1_lib.cc#L375).
+3. Load `https://localhost:4433` in Chromium.

--- a/chromium/README.md
+++ b/chromium/README.md
@@ -23,9 +23,11 @@ This directory contains instructions and corresponding patches to build the Chro
 
 6. Finally, follow the instructions [here](https://chromium.googlesource.com/chromium/src/+/master/docs/linux/build_instructions.md#Install-additional-build-dependencies) from the "Install additional build dependencies" section onwards to build Chromium.
 
-To verify that Chromium can perform a TLS 1.3 handshake using a post-quantum key exchange and authentication algorithm:
+To verify that Chromium can perform a TLS 1.3 handshake using a post-quantum key exchange:
 
 0. Navigate to `<CHROMIUM_ROOT>`, and start Chromium by executing `./out/Default/chrome --ignore-certificate-errors`
 1. Navigate again to the `<CHROMIUM_ROOT>/third_party/boringssl/src` folder, and build OQS-BoringSSL as a standalone project by following the instructions in that directory's `README.md` file.
-2. Then, in the `build` directory, run `./tool/bssl server -accept 4433 -www -loop -curves <KEX>`, where `<KEX>` can be any key-exchange algorithm that are both listed [here](https://github.com/open-quantum-safe/boringssl#supported-algorithms) and are listed in the array [here](https://github.com/open-quantum-safe/boringssl/blob/master/ssl/t1_lib.cc#L375).
+2. Then, in the `build` directory, run `./tool/bssl server -accept 4433 -www -loop -curves <KEX>`, where `<KEX>` can be any key-exchange algorithm named [here](https://github.com/open-quantum-safe/boringssl#supported-algorithms) that is supported by default by Chromium. The [kDefaultGroups array](https://github.com/open-quantum-safe/boringssl/blob/master/ssl/t1_lib.cc#L375) lists all such algorithms\*.
 3. Load `https://localhost:4433` in Chromium.
+
+\* For an explanation of why Chromium supports only a subset of key-exchange algorithms by default, consult [OQS-BoringSSL's Implementation Notes wiki page](https://github.com/open-quantum-safe/boringssl/wiki/Implementation-Notes).


### PR DESCRIPTION
This can go in once https://github.com/open-quantum-safe/boringssl/pull/22 does.