### PR TITLE
cert extensions for chromium added

### DIFF
--- a/nginx/fulltest/README.md
+++ b/nginx/fulltest/README.md
@@ -1,12 +1,13 @@
 # Scripts to generate OQS test server
 
-This folder contains all scripts to [build a QSC-enabled nginx server on ubuntu](build-ubuntu.sh) as well as generating all configuration files for running an interoperability test server: Running [python3 genconfig.py](genconfig.py) generates a local/self-signed root CA, all QSC certificates signed by this root CA for the currently supported list of QSC algorithms and the required nginx-server configuration file for a server running at the configured TESTFQDN (set by default to 'test.openquantumsafe.org').
+This folder contains all scripts to [build a QSC-enabled nginx server on ubuntu](build-ubuntu.sh) as well as generating all configuration files for running an interoperability test server: Running [python3 genconfig.py](genconfig.py) generates a local/self-signed root CA, all QSC certificates signed by this root CA for the currently supported list of QSC algorithms and the required nginx-server configuration file for a server running at the configured TESTFQDN server address.
 
 Also provided is a convenience file [package.sh](package.sh) that runs all build steps in one script generating an archive file ready to be deployed at an Ubuntu server.
 
-*Note*: These scripts assume presence 
-- on the build machine of a writable folder `/opt/nginx` for test-build (and local testing)
-- on the target deploy server (at TESTFQDN) of a properly deployed [LetsEncrypt server certificate](https://letsencrypt.org/getting-started).
+*Note*: These scripts assume 
+- coherent definition of test server FQDN as TESTFQDN in `genconfig.py` and `ext-csr.conf` files: By default "test.openquantumsafe.org" is set.
+- presence on the build machine of a writable folder `/opt/nginx` for test-build (and local testing)
+- presence on the target deploy server (i.e., at the machine designated at TESTFQDN) of a properly deployed [LetsEncrypt server certificate](https://letsencrypt.org/getting-started).
 
 ### HOWTO
 

--- a/nginx/fulltest/ext-csr.conf
+++ b/nginx/fulltest/ext-csr.conf
@@ -1,0 +1,14 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = test.openquantumsafe.org
+
+[v3_req]
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = test.openquantumsafe.org


### PR DESCRIPTION
The added `SubjectAlternateName` certificate extension enables QSC-Chromium to properly connect to test server. Certificates on [test.openquantumsafe.org](test.openquantumsafe.org) already updated.