### PR TITLE
version-enablement testserver

### DIFF
--- a/nginx/fulltest/build-ubuntu.sh
+++ b/nginx/fulltest/build-ubuntu.sh
@@ -4,6 +4,10 @@ export OPENSSL_PATH=/tmp/opt/openssl
 # define the nginx version to include
 export NGINX_VERSION=1.16.1
 
+# define the OQS releases to use, unset to deploy master branch
+export LIBOQS_RELEASE=0.4.0
+export OPENSSL_RELEASE=OQS-OpenSSL_1_1_1-stable-snapshot-2020-08
+
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 export MAKE_DEFINES="-j 4"
 
@@ -13,8 +17,14 @@ sudo apt install libtool automake autoconf cmake make openssl git wget libssl-de
 
 # get OQS sources
 rm -rf /tmp/opt && mkdir /tmp/opt && cd /tmp/opt
+if [ -z "$LIBOQS_RELEASE" ]; then
 git clone --depth 1 --branch master https://github.com/open-quantum-safe/liboqs && \
-git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl && \
+git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl 
+else
+echo "Deploying stable liboqs release ${LIBOQS_RELEASE}"
+wget https://github.com/open-quantum-safe/liboqs/archive/${LIBOQS_RELEASE}.tar.gz && tar xzvf ${LIBOQS_RELEASE}.tar.gz && mv liboqs-${LIBOQS_RELEASE} liboqs && \
+wget https://github.com/open-quantum-safe/openssl/archive/${OPENSSL_RELEASE}.tar.gz && tar xzvf ${OPENSSL_RELEASE}.tar.gz && mv openssl-${OPENSSL_RELEASE} openssl 
+fi
 wget nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && tar -zxvf nginx-${NGINX_VERSION}.tar.gz;
 
 # build liboqs (static only)

--- a/nginx/fulltest/index-template
+++ b/nginx/fulltest/index-template
@@ -36,7 +36,7 @@ tr:nth-child(even) {
 <li>curve IDs, code-points, and OIDs as specified in <a href="https://docs.google.com/spreadsheets/d/1xk0sQICZkzAZp_pzXu9BO-tHzoqmSFU7fB3Tk1rvQqs/edit?usp=sharing">this spreadsheet</a>.</li>
 </ul>
 
-<p>This corresponds to the OQS release version 0.4.0. </p>
+<p>This corresponds to the OQS release version LIBOQS_RELEASE </p>
 
 <p>These specifications should not be taken as a standard, de facto and otherwise, and are subject to change at any time.</p>
 
@@ -57,7 +57,7 @@ tr:nth-child(even) {
 <ol>
 <li>If not already done, download the test CA certificate from <a href="CA.crt">here</a> to the directory you want to execute your tests from.</li>
 <li>Select the algorithm combination to be tested from the list below. Assume this is <i>sig/kex (port)</i>.</li>
-<li>Connect to the corresponding port with a QSC-enabled client side software, e.g., curl. Using a ready-made docker image this could be facilitated by running <br><pre>docker run -v `pwd`:/ca -it openquantumsafe/curl:0.3.0 curl --cacert /ca/CA.crt https://test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre>Be sure to insert the <i>port</i> and <i>kex</i> values chosen above.<br>The test will be successful if a web page indicating successful connection establishment (and display of the OQS algorithm combination configured as well as the client-supported key exchange mechanism) is received.</li>
+<li>Connect to the corresponding port with a QSC-enabled client side software, e.g., curl. Using a ready-made docker image this could be facilitated by running <br><pre>docker run -v `pwd`:/ca -it openquantumsafe/curl:LIBOQS_RELEASE curl --cacert /ca/CA.crt https://test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre>Be sure to insert the <i>port</i> and <i>kex</i> values chosen above.<br>The test will be successful if a web page indicating successful connection establishment (and display of the OQS algorithm combination configured as well as the client-supported key exchange mechanism) is received.</li>
 </ol>
 
 <p>Notes: </p>
@@ -66,9 +66,9 @@ tr:nth-child(even) {
 <li><p>Another equally valid approach would be to build all required software from source and then execute it locally. Examples for this can be found in <a href="https://github.com/open-quantum-safe/oqs-demos">the OQS Github repository</a>.</p>
 <p>In this way, you could for example verify correct operation of all components using openssl's <i>s_client</i> function by running <pre>echo "GET /" | openssl s_client -CAfile CA.crt --connect test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre> Again, values for <i>port</i> and <i>kex</i> must be suitably set.</p></li>
 <li>Using "openssl s_client" has the additional benefit that it also displays the actual algorithms utilized: <i>Server Temp Key</i> describes the key exchange algorithm and <i>Peer signature type</i> the signature algorithm actually used.</li>
-<li>The OQS docker hub containers also provide a ready-made QSC-openssl distribution facilitating this test: You can do this for example with this command: <pre>docker run -v `pwd`:/ca -it openquantumsafe/curl:0.3.0 openssl s_client --connect test.openquantumsafe.org:6000 -CAfile /ca/CA.crt </pre> Then issue the <tt>GET /</tt> command on the command line to retrieve an information page.</li>
+<li>The OQS docker hub containers also provide a ready-made QSC-openssl distribution facilitating this test: You can do this for example with this command: <pre>docker run -v `pwd`:/ca -it openquantumsafe/curl:LIBOQS_RELEASE openssl s_client --connect test.openquantumsafe.org:6000 -CAfile /ca/CA.crt </pre> Then issue the <tt>GET /</tt> command on the command line to retrieve an information page.</li>
 <li>Using any algorithm with an 'oqs...default' name would necessitate client side software built with the exact same default algorithms set by the underlying OQS software. For details see <a href="https://github.com/open-quantum-safe/openssl/wiki/Using-liboqs-algorithms-not-in-the-fork">here</a>. Therefore interoperability testing against these algorithms may fail.</li>
-<li>The OQS docker images are pre-loaded with the test CA certificate which allow simplified testing bypassing the need to first obtain the test CA certificate and mounting this into the docker image. Therefore, testing a specific algorithm can be done simply without any preparation by running <br><pre>docker run -it openquantumsafe/curl:0.3.0 curl --cacert /opt/oqssa/oqs-testca.pem https://test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre></li>
+<li>The OQS docker images are pre-loaded with the test CA certificate which allow simplified testing bypassing the need to first obtain the test CA certificate and mounting this into the docker image. Therefore, testing a specific algorithm can be done simply without any preparation by running <br><pre>docker run -it openquantumsafe/curl:LIBOQS_RELEASE curl --cacert /opt/oqssa/oqs-testca.pem https://test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre></li>
 </ol>
 
 <h2> List of all supported QSC Signature / Key Exchange algorithms </h2>

--- a/nginx/fulltest/package.sh
+++ b/nginx/fulltest/package.sh
@@ -3,8 +3,11 @@
 # Script assumes nginx to have been built for this platform, e.g. using the build-ubuntu.sh script
 NGINX_INSTALL_DIR=/opt/nginx
 
-# cleanup: Beware - also kills root CA!
-rm -rf *.tgz pki root common.py *.html interop.conf assignments.json
+# Set this to document support of specific version. Be sure to keep this in sync with what is specified in build-ubuntu.sh.
+LIBOQS_RELEASE=0.4.0
+
+# cleanup: retaining root CA!
+rm -rf *.tgz pki common.py *.html interop.conf assignments.json
 
 # Obtain current list of algorithms
 wget https://raw.githubusercontent.com/open-quantum-safe/openssl/OQS-OpenSSL_1_1_1-stable/oqs-test/common.py
@@ -13,6 +16,9 @@ mkdir pki
 
 # Now generate config file, incl. CA and certs
 python3 genconfig.py
+
+# Be sure to set the proper RELEASE version:
+sed -i "s/LIBOQS_RELEASE/${LIBOQS_RELEASE}/g" index-base.html
 
 # Now move all piece-parts in place
 rm -rf ${NGINX_INSTALL_DIR}/pki


### PR DESCRIPTION
Automating testserver build to specific liboqs/openssl release. Result of this run now also live at https://test.openquantumsafe.org/ (0.4.0)