### PR TITLE
main branch renaming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ master, << pipeline.git.branch >> ]
+              - equal: [ main, << pipeline.git.branch >> ]
               - equal: [ true, << pipeline.parameters.new_openssl_commit >> ]
           steps:
             - run:


### PR DESCRIPTION
First step to eliminate master branch. If OK, please also set as default.