### PR TITLE
OpenSSL3 provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,12 @@ jobs:
           name: Authenticate to Docker
           command: echo $DOCKER_PASSWORD | docker login --username $DOCKER_LOGIN --password-stdin
       - run:
+          name: Test Provider
+          command: |
+            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-ossl3-img . &&
+            docker run --rm --name oqs-ossl3 oqs-ossl3-img sh -c "/opt/oqssa/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups kyber512 --CAfile /opt/oqssa/bin/CA.crt"
+          working_directory: openssl3
+      - run:
           name: Test Curl
           command: |
             # The CircleCI executor offers 35 cores, but using
@@ -71,12 +77,6 @@ jobs:
             sleep 2 &&
             docker run --network nginx-test oqs-curl-generic curl -k https://oqs-nginx:4433
           working_directory: nginx
-      - run:
-          name: Test Provider
-          command: |
-            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-ossl3-img . &&
-            docker run --rm --name oqs-ossl3 oqs-ossl3-img sh -c "/opt/oqssa/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups kyber512 --CAfile /opt/oqssa/bin/CA.crt"
-          working_directory: openssl3
       - when:
           condition:
             or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,9 @@ jobs:
                   docker tag oqs-haproxy-img $TARGETNAME/haproxy:latest &&
                   docker push $TARGETNAME/haproxy:latest &&
                   docker tag oqs-nginx-img $TARGETNAME/nginx:latest &&
-                  docker push $TARGETNAME/nginx:latest
+                  docker push $TARGETNAME/nginx:latest &&
+                  docker tag oqs-ossl3-img $TARGETNAME/oqs-ossl3:latest &&
+                  docker push $TARGETNAME/oqs-ossl3:latest
 
   ubuntu_x64_openssh:
     description: A template for building and pushing OQS demo Docker images on Ubuntu Bionic that do not use OQS-OpenSSL, but rather liboqs in another form (e.g. OQS-OpenSSH)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ localCheckout: &localCheckout
 
 jobs:
   ubuntu_x64_openssl:
-    description: A template for building and pushing OQS demo Docker images on Ubuntu Bionic that depend on OQS-OpenSSL
+    description: A template for building and pushing OQS demo Docker images on Ubuntu that depend on OQS-OpenSSL
     docker:
       - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
         auth:
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: Test Provider
           command: |
-            docker build --build-arg MAKE_DEFINES="-j 2" -t oqs-ossl3-img . &&
+            docker build --build-arg MAKE_DEFINES="-j 18" -t oqs-ossl3-img . &&
             docker run --rm --name oqs-ossl3 oqs-ossl3-img sh -c "/opt/oqssa/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups kyber512 --CAfile /opt/oqssa/bin/CA.crt"
           working_directory: openssl3
       - when:
@@ -102,7 +102,7 @@ jobs:
                   docker push $TARGETNAME/oqs-ossl3:latest
 
   ubuntu_x64_openssh:
-    description: A template for building and pushing OQS demo Docker images on Ubuntu Bionic that do not use OQS-OpenSSL, but rather liboqs in another form (e.g. OQS-OpenSSH)
+    description: A template for building and pushing OQS demo Docker images on Ubuntu that do not use OQS-OpenSSL, but rather liboqs in another form (e.g. OQS-OpenSSH)
     docker:
       - image: openquantumsafe/ci-ubuntu-focal-x86_64:latest
         auth:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,12 @@ jobs:
             sleep 2 &&
             docker run --network nginx-test oqs-curl-generic curl -k https://oqs-nginx:4433
           working_directory: nginx
+      - run:
+          name: Test Provider
+          command: |
+            docker build --build-arg MAKE_DEFINES="-j 2" -t oqs-ossl3-img . &&
+            docker run --rm --name oqs-ossl3 oqs-ossl3-img sh -c "/opt/oqssa/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups kyber512 --CAfile /opt/oqssa/bin/CA.crt"
+          working_directory: openssl3
       - when:
           condition:
             or:

--- a/chromium/README.md
+++ b/chromium/README.md
@@ -50,4 +50,6 @@ An alternative test consists of using the newly built Chromium to access the OQS
 
 Note: In order to avoid certificate warnings, you need to [download the test site certificate](https://test.openquantumsafe.org/CA.crt) using the newly-built chromium. Then click the "..." Control extensions button in the top-right window corner of your newly built Chromium browser, select "Settings", click on "Privacy and Security" in the newly opened window on the left, click on "Security" in the window pane on the right, scroll down and click on "Manage certificates", click on the "Certificates" tab in the newly opened screen, click on "Import" near the top of the newly opened pane and click on the "Downloads" folder on the file selector window that opens. Then double-click on "CA.crt" and check the box next to "Trust this certificate for identifying websites" and finally click "OK".
 
+*Note: If you already had been running an OQS-enabled chromium and upgraded to a more current version, clearing the cache is strongly advised to avoid "inexplicable" errors.*
+
 \* For an explanation of why Chromium supports only a subset of key-exchange algorithms by default, consult [OQS-BoringSSL's Implementation Notes wiki page](https://github.com/open-quantum-safe/boringssl/wiki/Implementation-Notes).

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -1,0 +1,107 @@
+# Multi-stage build: First the full builder image:
+
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
+
+# liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
+ARG LIBOQS_BUILD_DEFINES=
+
+# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
+ARG MAKE_DEFINES="-j 2"
+
+# Change this at your own risk: oqs-provider & OSSL3 cannot yet properly handle OQS-sigs
+ARG SIG_ALG="rsa"
+
+FROM alpine:3.13 as intermediate
+# Take in all global args
+ARG CURL_VERSION
+ARG INSTALLDIR
+ARG LIBOQS_BUILD_DEFINES
+ARG MAKE_DEFINES
+ARG SIG_ALG
+
+LABEL version="1"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apk update && apk upgrade
+
+# Get all software packages required for builing all components:
+RUN apk add build-base linux-headers \
+            libtool automake autoconf cmake ninja \
+            make \
+            openssl openssl-dev \
+            git docker wget
+
+# get all sources
+WORKDIR /opt
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
+    git clone --depth 1 --branch master https://github.com/openssl/openssl.git && \
+    git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git 
+
+WORKDIR /opt/liboqs
+RUN mkdir build && cd build && cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
+
+# build OpenSSL3
+WORKDIR /opt/openssl
+# curl looks for shared libraries
+# at ./configure time
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTALLDIR} && \
+    make ${MAKE_DEFINES} && make install;
+
+# set path to use 'new' openssl & curl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# build & install provider (and activate by default)
+WORKDIR /opt/oqs-provider
+RUN cmake -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${INSTALLDIR} -S . -B _build && cmake --build _build && cp _build/oqsprov/oqsprovider.so ${INSTALLDIR}/lib/ossl-modules && sed -i "s/default = default_sect/default = default_sect\noqsprovider = oqsprovider_sect/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/\[default_sect\]/\[default_sect\]\nactivate = 1\n\[oqsprovider_sect\]\nactivate = 1\n/g" /opt/oqssa/ssl/openssl.cnf
+
+# generate certificates for openssl s_server, which is what we will test curl against
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+
+WORKDIR ${INSTALLDIR}/bin
+# generate CA key and cert
+RUN set -x; \
+    ${OPENSSL} req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365 -config ${OPENSSL_CNF}
+
+## second stage: Only create minimal image without build tooling and intermediate build results generated above:
+FROM alpine:3.13 as dev
+# Take in all global args
+ARG INSTALLDIR
+ARG SIG_ALG
+
+# Only retain the ${INSTALLDIR} contents in the final image
+COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}
+
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# generate certificates for openssl s_server, which is what we will test curl against
+ENV OPENSSL=${INSTALLDIR}/bin/openssl
+ENV OPENSSL_CNF=${INSTALLDIR}/ssl/openssl.cnf
+
+WORKDIR ${INSTALLDIR}/bin
+
+# oqs-provider cannot deal with OQS sigs, so use classic crypto for sigs
+# generate server CSR using pre-set CA.key and cert
+# and generate server cert
+RUN set -x && mkdir /opt/test; \
+    ${OPENSSL} req -new -newkey ${SIG_ALG} -keyout /opt/test/server.key -out /opt/test/server.csr -nodes -subj "/CN=localhost" -config ${OPENSSL_CNF}; \
+    ${OPENSSL} x509 -req -in /opt/test/server.csr -out /opt/test/server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
+
+COPY serverstart.sh ${INSTALLDIR}/bin
+
+WORKDIR ${INSTALLDIR}
+
+FROM dev
+ARG INSTALLDIR
+
+WORKDIR /
+
+# Enable a normal user to create new server keys off set CA
+RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs /opt/test && chmod go+r ${INSTALLDIR}/bin/CA.key 
+
+#USER oqs
+CMD ["serverstart.sh"]
+STOPSIGNAL SIGTERM

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -4,8 +4,6 @@
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-# by default OFF as McEliece AVX otherwise fails to link (TBD)
-#ARG LIBOQS_BUILD_DEFINES=-DOQS_USE_CPU_EXTENSIONS=OFF
 ARG LIBOQS_BUILD_DEFINES=
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
@@ -39,7 +37,7 @@ RUN apk add build-base linux-headers \
 WORKDIR /opt
 RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
     git clone --depth 1 --branch master https://github.com/openssl/openssl.git && \
-    git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git 
+    git clone --depth 1 --branch mb-linkmceliece https://github.com/open-quantum-safe/oqs-provider.git
 
 WORKDIR /opt/liboqs
 RUN mkdir build && cd build && cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -4,7 +4,8 @@
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-ARG LIBOQS_BUILD_DEFINES=
+# Disable AVX for ClassicMcEliece until liboqs fix lands
+ARG LIBOQS_BUILD_DEFINES=-DBUILD_SHARED_LIBS=ON -DOQS_ENABLE_KEM_classic_mceliece_348864_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_348864f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119_avx=OFF
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"
@@ -37,7 +38,7 @@ RUN apk add build-base linux-headers \
 WORKDIR /opt
 RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
     git clone --depth 1 --branch master https://github.com/openssl/openssl.git && \
-    git clone --depth 1 --branch mb-linkmceliece https://github.com/open-quantum-safe/oqs-provider.git
+    git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
 
 WORKDIR /opt/liboqs
 RUN mkdir build && cd build && cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -5,7 +5,8 @@ ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
 # by default OFF as McEliece AVX otherwise fails to link (TBD)
-ARG LIBOQS_BUILD_DEFINES=-DOQS_USE_CPU_EXTENSIONS=OFF
+#ARG LIBOQS_BUILD_DEFINES=-DOQS_USE_CPU_EXTENSIONS=OFF
+ARG LIBOQS_BUILD_DEFINES=
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -4,7 +4,8 @@
 ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-ARG LIBOQS_BUILD_DEFINES=
+# by default OFF as McEliece AVX otherwise fails to link (TBD)
+ARG LIBOQS_BUILD_DEFINES=-DOQS_USE_CPU_EXTENSIONS=OFF
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -5,7 +5,7 @@ ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
 # Disable AVX for ClassicMcEliece until liboqs fix lands
-ARG LIBOQS_BUILD_DEFINES=-DBUILD_SHARED_LIBS=ON -DOQS_ENABLE_KEM_classic_mceliece_348864_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_348864f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119_avx=OFF
+ARG LIBOQS_BUILD_DEFINES="-DBUILD_SHARED_LIBS=ON -DOQS_ENABLE_KEM_classic_mceliece_348864_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_348864f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119_avx=OFF"
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -5,7 +5,7 @@ ARG INSTALLDIR=/opt/oqssa
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
 # Disable AVX for ClassicMcEliece until liboqs fix lands
-ARG LIBOQS_BUILD_DEFINES="-DBUILD_SHARED_LIBS=ON -DOQS_ENABLE_KEM_classic_mceliece_348864_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_348864f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119_avx=OFF"
+ARG LIBOQS_BUILD_DEFINES="-DOQS_ENABLE_KEM_classic_mceliece_348864_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_348864f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119_avx=OFF"
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"
@@ -45,8 +45,6 @@ RUN mkdir build && cd build && cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAK
 
 # build OpenSSL3
 WORKDIR /opt/openssl
-# curl looks for shared libraries
-# at ./configure time
 RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib" ./config shared --prefix=${INSTALLDIR} && \
     make ${MAKE_DEFINES} && make install;
 

--- a/openssl3/README.md
+++ b/openssl3/README.md
@@ -1,0 +1,58 @@
+This directory contains a Dockerfile that builds OpenSSL3 master with the [OQS provider](https://github.com/open-quantum-safe/oqs-provider), which allows openssl3 to use quantum-safe key exchange in TLS 1.3.
+
+## Quick start
+
+1) Be sure to have [docker installed](https://docs.docker.com/install).
+2) Run `docker build -t oqs-ossl3 .` to create a post quantum-enabled OpenSSL3 image
+3) To verify all components perform quantum-safe operations, first start the container with `docker run -it oqs-ossl3` thus starting an OQS-enabled TLS test server.
+4) On the command prompt in the docker container query that server using `openssl s_client -connect localhost --groups kyber512 `. If all works, the last command returns all TLS information documenting use of OQS-enabled TLS. The parameter to the `--groups` argument is the KEM_ALG chosen when building the docker container ('kyber512' by default).
+
+*Note*: The last command creates a HTTP command window into the sample server. It can be exited either by typing CTRL-C or by issuing a valid command, e.g., `GET /`. The latter command will also return server-side information on the protocol and cryptographic methods used, e.g., the TLS 1.3 group actually used (kyber512 in this example).
+
+
+## More details
+
+The Dockerfile 
+- obtains all source code required for building the quantum-safe crypto (QSC) algorithms, the QSC-provider and OpenSSL3 (master).
+- builds all libraries and applications
+- by default starts an openssl (s_server) based test server.
+
+**Note for the interested**: The build process is two-stage with the final image only retaining all executables, libraries and include-files to utilize OQS-enabled openssl3.
+
+One runtime configuration option exists that can be optionally set via docker environment variable:
+
+Setting the key exchange mechanism (KEM): By setting 'KEM_ALG'
+to any of the [supported KEM algorithms built into OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange) one can run TLS using a KEM other than the default algorithm 'kyber512'. Example: `docker run -e KEM_ALG=ntru_hps2048509 -it oqs-ossl3`. It is always necessary to also request use of this KEM algorithm by passing it to the invocation of `openssl s_client` with the `--groups` parameter, i.e. as such in the same example: `openssl s_client -connect localhost --groups ntru_hps2048509 `.
+
+## Usage
+
+Information how to use the image is [available in the separate file USAGE.md](USAGE.md).
+
+## Build options
+
+The Dockerfile provided allows for significant customization of the image built:
+
+### LIBOQS_BUILD_DEFINES
+
+This permits changing the build options for the underlying library with the quantum safe algorithms. All possible options are documented [here](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs).
+
+By default, the image is built such as to have maximum portability regardless of CPU type and optimizations available, i.e. to run on the widest possible range of cloud machines.
+
+### OPENSSL_BUILD_DEFINES
+
+This permits changing the build options for the underlying openssl library containing the quantum safe algorithms. 
+
+The default setting defines a range of default algorithms suggested for key exchange. For more information see [the documentation](https://github.com/open-quantum-safe/openssl#default-algorithms-announced).
+
+### INSTALLDIR
+
+This defines the resultant location of the software installatiion.
+
+By default this is '/opt/oqssa'. It is recommended to not change this. Also, all [usage documentation](USAGE.md) assumes this path.
+
+### MAKE_DEFINES
+
+Allow setting parameters to `make` operation, e.g., '-j nnn' where nnn defines the number of jobs run in parallel during build.
+
+The default is conservative and known not to overload normal machines. If one has a very powerful (many cores, >64GB RAM) machine, passing larger numbers (or only '-j' for maximum parallelism) speeds up building considerably.
+

--- a/openssl3/USAGE.md
+++ b/openssl3/USAGE.md
@@ -1,0 +1,22 @@
+# OQS-ossl3
+
+This docker image contains a version of [OpenSSL3](https://github.com/openssl/openssl) built and extended with a [provider enabling quantum-safe crypto (QSC) operations](https://github.com/open-quantum-safe/oqs-provider).
+
+To this end, it contains [liboqs](https://github.com/open-quantum-safe/liboqs) as well as [OpenSSL 3/master](https://github.com/openssl/openssl) and [oqs-provider](https://github.com/open-quantum-safe/oqs-provider) from the [OpenQuantumSafe](https://openquantumsafe.org) project.
+
+As different images providing the same base functionality may be available, e.g., for debug or performance-optimized operations, the image name `oqs-ossl3` is consistently used in the description below. Be sure to adapt it to the image you want to use.
+
+## Quick start
+
+1) With `docker run -it oqs-ossl3` start an OQS-enabled TLS test server.
+2) On the command prompt in the docker container resulting from the first comment, one can query that server by issuing the command `openssl s_client -connect localhost --groups kyber512`. 
+
+The latter command returns all TLS information documenting use of OQS-enabled TLS. The parameter to the `--groups` argument is [any Kex Exchange algorithm supported by OQS-OpenSSL](https://github.com/open-quantum-safe/openssl#key-exchange).
+
+## Retrieving data from other QSC-enabled TLS servers
+
+Beyond interacting with the built-in test server (utilizing `openssl s_server`) the image can also be used to retrieve data from any OQS-enabled TLS (1.3) server with the command `docker run -it oqs-ossl3 openssl s_client -connect <OQS-server address:port> --groups <suitable KEM>`.
+
+## Limitations
+
+This image is limited in functionality as per the [open issues documented for oqs-provider](https://github.com/open-quantum-safe/oqs-provider/issues).

--- a/openssl3/USAGE.md
+++ b/openssl3/USAGE.md
@@ -19,4 +19,4 @@ Beyond interacting with the built-in test server (utilizing `openssl s_server`) 
 
 ## Limitations
 
-This image is limited in functionality as per the [open issues documented for oqs-provider](https://github.com/open-quantum-safe/oqs-provider/issues).
+This image is limited in functionality as per the [open issues documented for oqs-provider](https://github.com/open-quantum-safe/oqs-provider/issues). It also is [not fit for productive use](https://github.com/open-quantum-safe/openssl#limitations-and-security).

--- a/openssl3/fulltest/testrun.py
+++ b/openssl3/fulltest/testrun.py
@@ -1,0 +1,31 @@
+import json
+import sys
+import subprocess
+import os
+import time
+
+# Parameter checks already done in shellscript
+
+with open("assignments.json", "r") as f:
+   jsoncontents = f.read();
+
+assignments = json.loads(jsoncontents)
+for sig in assignments:
+    print("Testing %s:" % (sig))
+    for kem in assignments[sig]:
+     if not "_" in kem: # hybrids not yet supported in OSSL3-oqsprovider: TBD
+       # assemble testing command
+       cmd = "docker run -v "+os.path.abspath(os.getcwd())+"/ca:/ca -it "+sys.argv[1]+" sh -c \"(echo \'GET /\'; sleep 1) | openssl s_client -CAfile /ca/CA.crt -connect test.openquantumsafe.org:"+str(assignments[sig][kem])
+       if kem!="*": # don't prescribe KEM
+          cmd=cmd+" -groups "+kem
+       cmd=cmd+"\""
+       output = os.popen(cmd).read()
+       if not ("Successfully" in output):
+           print("Error" +output)
+       else:
+          print("    Tested KEM %s successfully." % (kem))
+    print("  Successfully concluded testing "+sig) 
+    break # only a single sig round makes sense until all OQS sigs are supported by OSSL3-oqsprovider (TBD)
+print("All available tests successfully passed.")
+
+

--- a/openssl3/fulltest/testrun.sh
+++ b/openssl3/fulltest/testrun.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Arg1 is docker image to use as client
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} <docker-image name>. Exiting."
+    exit 1
+fi
+
+# prepare test
+rm -rf ca assignments.json* 
+mkdir ca
+# pull current CA cert
+cd ca
+wget https://test.openquantumsafe.org/CA.crt
+cd ..
+
+# pull list of algs/ports
+wget https://test.openquantumsafe.org/assignments.json
+
+# execute test
+python3 testrun.py ${1}

--- a/openssl3/serverstart.sh
+++ b/openssl3/serverstart.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Optionally set KEM to one defined in https://github.com/open-quantum-safe/openssl#key-exchange
+if [ "x$KEM_ALG" == "x" ]; then
+	export KEM_ALG=kyber512
+fi
+
+# OQS sig certs not yet supported in OSSL3 oqsprovider
+
+# Start a TLS1.3 test server based on OpenSSL accepting only the specified KEM_ALG
+openssl s_server -cert /opt/test/server.crt -key /opt/test/server.key -groups $KEM_ALG -www -tls1_3 -accept localhost:4433&
+
+# Open a shell for local experimentation
+sh


### PR DESCRIPTION
This "dockerizes" the `oqs-provider`.
Also available is the script `fulltest/testrun.sh` to test-drive/ensure interoperability of the resultant image against `test.openquantumsafe.org`.