### PR TITLE
update liboqs build flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ jobs:
             docker run -e TEST_TIME=5 -e KEM_ALG=kyber768 -e SIG_ALG=dilithium3 -it oqs-curl perftest.sh 
           working_directory: curl
       - run:
-          name: Test Curl with portable liboqs
+          name: Test Curl with generic liboqs
           command: |
-            docker build --build-arg MAKE_DEFINES="-j 18" --build-arg LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF" -t oqs-curl-generic . &&
-            docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1full -it oqs-curl perftest.sh 
+            docker build --build-arg MAKE_DEFINES="-j 18" --build-arg LIBOQS_BUILD_DEFINES="-DOQS_OPT_TARGET=generic" -t oqs-curl-generic . &&
+            docker run -e TEST_TIME=5 -e KEM_ALG=sikep751 -e SIG_ALG=picnicl1full -it oqs-curl-generic perftest.sh 
           working_directory: curl
       - run:
           name: Test Apache httpd

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -6,8 +6,8 @@ ARG CURL_VERSION=7.73.0
 # Default location where all binaries wind up:
 ARG INSTALLDIR=/opt/oqssa
 
-# liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-ARG LIBOQS_BUILD_DEFINES=
+# liboqs build type variant; maximum portability of image:
+ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
 # openssl build defines (https://github.com/open-quantum-safe/openssl#build-options)
 ARG OPENSSL_BUILD_DEFINES="-DOQS_DEFAULT_GROUPS=p384_kyber768:X25519:kyber768"

--- a/curl/README.md
+++ b/curl/README.md
@@ -37,7 +37,7 @@ The Dockerfile also facilitates building the underlying OQS library to different
 
 For example, with this build command
 ```
-docker build --build-arg LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF" -f Dockerfile -t oqs-curl-generic .
+docker build --build-arg LIBOQS_BUILD_DEFINES="-DOQS_OPT_TARGET=generic" -f Dockerfile -t oqs-curl-generic .
 ``` 
 a generic system without processor-specific runtime optimizations is built, thus ensuring execution on all computers (at the cost of maximum runtime performance).
 

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -2,8 +2,8 @@
 
 # First: global build arguments: 
 
-# liboqs build type variant; build non-optimized by default (maximum portability of image):
-ARG LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF"
+# liboqs build type variant; maximum portability of image:
+ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
 ARG BUILDDIR=/root
 

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -2,8 +2,8 @@
 
 # First: global build arguments: 
 
-# liboqs build type variant; build non-optimized by default (maximum portability of image):
-ARG LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF"
+# liboqs build type variant; maximum portability of image:
+ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
 # installation paths
 ARG OPENSSL_PATH=/opt/openssl

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -2,8 +2,8 @@
 
 # First: global build arguments:
 
-# liboqs build type variant; build non-optimized by default (maximum portability of image):
-ARG LIBOQS_BUILD_DEFINES="-DOQS_USE_CPU_EXTENSIONS=OFF"
+# liboqs build type variant; maximum portability of image:
+ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
 # installation paths
 ARG OPENSSL_PATH=/opt/openssl

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -3,9 +3,8 @@
 # Default location where all binaries wind up:
 ARG INSTALLDIR=/opt/oqssa
 
-# liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
-# Disable AVX for ClassicMcEliece until liboqs fix lands
-ARG LIBOQS_BUILD_DEFINES="-DOQS_ENABLE_KEM_classic_mceliece_348864_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_348864f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_8192128f_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_460896_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6688128_avx=OFF -DOQS_ENABLE_KEM_classic_mceliece_6960119_avx=OFF"
+# liboqs build type variant; maximum portability of image:
+ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j 2"


### PR DESCRIPTION
Update all Docker images & documentation to use new/current [liboqs build options](https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs#OQS_OPT_TARGET)