### PR TITLE
enable provider hybrid KEM testing

### DIFF
--- a/openssl3/fulltest/testrun.py
+++ b/openssl3/fulltest/testrun.py
@@ -13,7 +13,6 @@ assignments = json.loads(jsoncontents)
 for sig in assignments:
     print("Testing %s:" % (sig))
     for kem in assignments[sig]:
-     if not "_" in kem: # hybrids not yet supported in OSSL3-oqsprovider: TBD
        # assemble testing command
        cmd = "docker run -v "+os.path.abspath(os.getcwd())+"/ca:/ca -it "+sys.argv[1]+" sh -c \"(echo \'GET /\'; sleep 1) | openssl s_client -CAfile /ca/CA.crt -connect test.openquantumsafe.org:"+str(assignments[sig][kem])
        if kem!="*": # don't prescribe KEM
@@ -21,7 +20,7 @@ for sig in assignments:
        cmd=cmd+"\""
        output = os.popen(cmd).read()
        if not ("Successfully" in output):
-           print("Error" +output)
+           print("Error testing %s: \n %s \n" % (kem, output))
        else:
           print("    Tested KEM %s successfully." % (kem))
     print("  Successfully concluded testing "+sig) 


### PR DESCRIPTION
Splitting out the hybrid KEM interop test server enablement (inadvertently in #84)