### PR TITLE
working around latest alpine make bug

### DIFF
--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -22,7 +22,7 @@ ARG HAPROXY_VERSION=2.2.6
 ARG MAKE_DEFINES=""
 
 
-FROM alpine as intermediate
+FROM alpine:3.11 as intermediate
 
 # Take in global args
 ARG INSTALLPATH
@@ -76,7 +76,7 @@ RUN set -x && \
     ${INSTALLPATH}/bin/openssl x509 -req -in pki/server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey cacert/CA.key -CAcreateserial -days 365
 
 # second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine
+FROM alpine:3.11
 # Take in global args
 ARG HAPROXY_PATH
 ARG INSTALLPATH

--- a/haproxy/Dockerfile
+++ b/haproxy/Dockerfile
@@ -22,7 +22,8 @@ ARG HAPROXY_VERSION=2.2.6
 ARG MAKE_DEFINES=""
 
 
-FROM alpine:3.11 as intermediate
+FROM alpine:3.13 as intermediate
+# ToDo: Upgrade possible if https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2 addressed
 
 # Take in global args
 ARG INSTALLPATH
@@ -76,7 +77,7 @@ RUN set -x && \
     ${INSTALLPATH}/bin/openssl x509 -req -in pki/server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey cacert/CA.key -CAcreateserial -days 365
 
 # second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:3.11
+FROM alpine:3.13
 # Take in global args
 ARG HAPROXY_PATH
 ARG INSTALLPATH

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -19,7 +19,9 @@ ARG HTTPD_VERSION=2.4.43
 ARG MAKE_DEFINES="-j 2"
 
 
-FROM alpine:3.11 as intermediate
+FROM alpine:3.13 as intermediate
+# ToDo: Upgrade possible if https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2 addressed
+
 # Take in global args
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_PATH
@@ -90,7 +92,7 @@ RUN set -x && \
 RUN rm -rf ${HTTPD_PATH}/bin/ab
 
 # second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:3.11
+FROM alpine:3.13
 # Take in global args
 ARG HTTPD_PATH
 ARG OPENSSL_PATH

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -19,7 +19,7 @@ ARG HTTPD_VERSION=2.4.43
 ARG MAKE_DEFINES="-j 2"
 
 
-FROM alpine as intermediate
+FROM alpine:3.11 as intermediate
 # Take in global args
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_PATH
@@ -90,7 +90,7 @@ RUN set -x && \
 RUN rm -rf ${HTTPD_PATH}/bin/ab
 
 # second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine
+FROM alpine:3.11
 # Take in global args
 ARG HTTPD_PATH
 ARG OPENSSL_PATH

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -19,7 +19,8 @@ ARG NGINX_VERSION=1.16.1
 ARG MAKE_DEFINES="-j 2"
 
 
-FROM alpine:3.11 as intermediate
+FROM alpine:3.13 as intermediate
+# ToDo: Upgrade possible if https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2 addressed
 # Take in global args
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_PATH
@@ -70,7 +71,7 @@ RUN set -x && \
     ${OPENSSL_PATH}/apps/openssl x509 -req -in server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey CA.key -CAcreateserial -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:3.11
+FROM alpine:3.13
 # Take in global args
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_PATH

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -19,7 +19,7 @@ ARG NGINX_VERSION=1.16.1
 ARG MAKE_DEFINES="-j 2"
 
 
-FROM alpine as intermediate
+FROM alpine:3.11 as intermediate
 # Take in global args
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_PATH
@@ -70,7 +70,7 @@ RUN set -x && \
     ${OPENSSL_PATH}/apps/openssl x509 -req -in server.csr -out pki/server.crt -CA cacert/CA.crt -CAkey CA.key -CAcreateserial -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine 
+FROM alpine:3.11
 # Take in global args
 ARG LIBOQS_BUILD_DEFINES
 ARG OPENSSL_PATH


### PR DESCRIPTION
Latest Alpine increased security settings that CCI doesn't --yet-- support: Instead of implementing a workaround as per https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2 this PR fixes alpine to 3.13 (in support until November 2022).