### PR TITLE
default alg removal

### DIFF
--- a/openssh/Dockerfile
+++ b/openssh/Dockerfile
@@ -6,7 +6,7 @@ ARG INSTALL_DIR=${DEFAULT_INSTALL_DIR}
 
 # liboqs version
 # ATTENTION: Changing this could mean that further adaptions in sshd_config and ssh_config are required
-ARG LIBOQS_RELEASE="0.6.0"
+ARG LIBOQS_RELEASE="main"
 
 # liboqs build defines (https://github.com/open-quantum-safe/liboqs/wiki/Customizing-liboqs)
 ARG LIBOQS_BUILD_DEFINES=

--- a/openssh/ssh_config
+++ b/openssh/ssh_config
@@ -43,21 +43,18 @@ Port 2222
 #IdentityFile ~/.ssh/id_dsa
 #IdentityFile ~/.ssh/id_ed25519
 
-#IdentityFile ~/.ssh/id_ssh-oqsdefault
 #IdentityFile ~/.ssh/id_ssh-dilithium2aes
 #IdentityFile ~/.ssh/id_ssh-falcon512
 #IdentityFile ~/.ssh/id_ssh-picnicL1full
 #IdentityFile ~/.ssh/id_ssh-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-sphincsharaka128fsimple
 
-#IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-oqsdefault
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-dilithium2aes
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-falcon512
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-picnicL1full
 IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-sphincsharaka128fsimple
 
-#IdentityFile ~/.ssh/id_ssh-rsa3072-oqsdefault
 #IdentityFile ~/.ssh/id_ssh-rsa3072-dilithium2aes
 #IdentityFile ~/.ssh/id_ssh-rsa3072-falcon512
 #IdentityFile ~/.ssh/id_ssh-rsa3072-picnicL1full

--- a/openssh/sshd_config
+++ b/openssh/sshd_config
@@ -33,18 +33,15 @@ Port 2222
 #HostKey /opt/oqs-ssh/ssh_host_dsa_key
 #HostKey /opt/oqs-ssh/ssh_host_ed25519_key
 
-#HostKey /opt/oqs-ssh/ssh_host_ssh-oqsdefault_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-dilithium2aes_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-falcon512_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-picnicL1full_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-sphincsharaka192frobust_key
 
-#HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp256-oqsdefault_key
 HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp384-dilithium3_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp256-falcon512_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp384-picnicL3FS_key
 
-#HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-oqsdefault_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-dilithium2aes_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-falcon512_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-picnicL1full_key


### PR DESCRIPTION
- detach openssh from liboqs 0.6.0
- remove references to OQS default algs