### PR TITLE
Change openssh default host key algo to dilithium

### DIFF
--- a/openssh/USAGE.md
+++ b/openssh/USAGE.md
@@ -175,7 +175,7 @@ docker exec -it <name-or-hash-of-container> /opt/oqs-ssh/scripts/key-gen.sh
 
 For a list of all signature and key exchange algorithms see [here](https://github.com/open-quantum-safe/openssh#supported-algorithms). Be aware that there is a limitation of what algorithms are enabled in PQS-OpenSSH per default, more information in the section **Enabling additional PQC algorithms** below. It is recommended to only use the hybrid variants to maintain established classical security. The post-quantum safe algorithms have not yet received enough confidence to be relied on as the only security mechanism.
 
-The image's default key exchange algorithm is `ecdh-nistp384-kyber-768-sha384`. For host and identity keys (server and client authentication, respectively) algorithms `ssh-ecdsa-nistp384-dilithium3` and `ssh-ecdsa-nistp384-picnicL3FS` are used. Those algorithms may be changed by adjusting the files `ssh_config` and `sshd_config` respectively.
+The image's default key exchange algorithm is `ecdh-nistp384-kyber-768-sha384`. For host and identity keys (server and client authentication, respectively) the `ssh-ecdsa-nistp384-dilithium3` algorithm is used. Those algorithms may be changed by adjusting the files `ssh_config` and `sshd_config` respectively.
 
 **In `ssh_config` (client side)**
 - `KexAlgorithms`: Comma-separated list of enabled key-exchange algorithms. Priority given by order. Names according to [this KEX naming scheme](https://github.com/open-quantum-safe/openssh#key-exchange).

--- a/openssh/ssh_config
+++ b/openssh/ssh_config
@@ -49,10 +49,10 @@ Port 2222
 #IdentityFile ~/.ssh/id_ssh-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-sphincsharaka128fsimple
 
-#IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-dilithium2aes
+IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-dilithium2aes
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-falcon512
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-picnicL1full
-IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-picnicL3FS
+#IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-sphincsharaka128fsimple
 
 #IdentityFile ~/.ssh/id_ssh-rsa3072-dilithium2aes

--- a/openssh/ssh_config
+++ b/openssh/ssh_config
@@ -49,7 +49,7 @@ Port 2222
 #IdentityFile ~/.ssh/id_ssh-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-sphincsharaka128fsimple
 
-IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-dilithium2aes
+IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-dilithium3
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-falcon512
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-picnicL1full
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-picnicL3FS

--- a/openssh/ssh_config
+++ b/openssh/ssh_config
@@ -45,19 +45,14 @@ Port 2222
 
 #IdentityFile ~/.ssh/id_ssh-dilithium2aes
 #IdentityFile ~/.ssh/id_ssh-falcon512
-#IdentityFile ~/.ssh/id_ssh-picnicL1full
-#IdentityFile ~/.ssh/id_ssh-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-sphincsharaka128fsimple
 
 IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-dilithium3
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-falcon512
-#IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-picnicL1full
-#IdentityFile ~/.ssh/id_ssh-ecdsa-nistp384-picnicL3FS
 #IdentityFile ~/.ssh/id_ssh-ecdsa-nistp256-sphincsharaka128fsimple
 
 #IdentityFile ~/.ssh/id_ssh-rsa3072-dilithium2aes
 #IdentityFile ~/.ssh/id_ssh-rsa3072-falcon512
-#IdentityFile ~/.ssh/id_ssh-rsa3072-picnicL1full
 #IdentityFile ~/.ssh/id_ssh-rsa3072-sphincsharaka128fsimple
 
 ###############################################################################

--- a/openssh/sshd_config
+++ b/openssh/sshd_config
@@ -35,16 +35,13 @@ Port 2222
 
 #HostKey /opt/oqs-ssh/ssh_host_ssh-dilithium2aes_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-falcon512_key
-#HostKey /opt/oqs-ssh/ssh_host_ssh-picnicL1full_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-sphincsharaka192frobust_key
 
 HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp384-dilithium3_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp256-falcon512_key
-#HostKey /opt/oqs-ssh/ssh_host_ssh-ecdsa-nistp384-picnicL3FS_key
 
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-dilithium2aes_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-falcon512_key
-#HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-picnicL1full_key
 #HostKey /opt/oqs-ssh/ssh_host_ssh-rsa3072-sphincsharaka128fsimple_key
 
 


### PR DESCRIPTION
Follow up from discussion in https://github.com/open-quantum-safe/oqs-demos/issues/185#issuecomment-1451942190 , where changing the default host key algo to dilithium was mentioned. 