### PR TITLE
Adds docker build to generate test server package

### DIFF
--- a/nginx/fulltest-provider/Dockerfile
+++ b/nginx/fulltest-provider/Dockerfile
@@ -1,0 +1,139 @@
+# Multi-stage build: First the full builder image:
+
+# First: global build arguments:
+
+# liboqs build type variant; maximum portability of image:
+ARG LIBOQS_VERSION=0.8.0-rc1
+
+ARG OPENSSL_VERSION=master
+
+ARG OQS_PROVIDER_VERSION=main
+
+ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
+
+# base install path
+ARG BASEDIR="/opt"
+
+# installation paths
+ARG INSTALLDIR=${BASEDIR}/nginx
+
+ARG CONFIGDIR="/"
+
+# defines the QSC signature algorithm used for the certificates:
+ARG SIG_ALG="dilithium3"
+
+# defines the list of default groups to be activated in nginx-openssl config:
+ARG DEFAULT_GROUPS=x25519:x448:kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024
+
+# define the nginx version to include
+ARG NGINX_VERSION=1.24.0
+
+# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
+ARG MAKE_DEFINES="-j128"
+
+FROM ubuntu:focal-20230412 as intermediate
+# Take in global args
+ARG BASEDIR
+ARG CONFIGDIR
+ARG LIBOQS_VERSION
+ARG OPENSSL_VERSION
+ARG OQS_PROVIDER_VERSION
+ARG LIBOQS_BUILD_DEFINES
+ARG INSTALLDIR
+ARG SIG_ALG
+ARG NGINX_VERSION
+ARG MAKE_DEFINES
+ARG DEFAULT_GROUPS
+ARG OSSLDIR=${BASEDIR}/openssl/.openssl
+
+ENV DEBIAN_FRONTEND noninteractive
+# Get all software packages required for builing all components (probably not all are really needed):
+RUN apt update && apt install -y sed libpcre3 libpcre3-dev libtool automake autoconf openssl libssl-dev build-essential git cmake astyle gcc ninja-build libssl-dev python3-pytest python3-psutil python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml valgrind wget
+
+# get OQS sources
+WORKDIR /opt
+RUN git clone --depth 1 --branch ${LIBOQS_VERSION} https://github.com/open-quantum-safe/liboqs && \
+    git clone --depth 1 --branch ${OQS_PROVIDER_VERSION} https://github.com/open-quantum-safe/oqs-provider.git && \
+    git clone --depth 1 --branch ${OPENSSL_VERSION} https://github.com/openssl/openssl.git && \
+    wget nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && tar -zxvf nginx-${NGINX_VERSION}.tar.gz;
+
+# build liboqs (static only)
+WORKDIR /opt/liboqs
+RUN mkdir build && cd build && cmake -G"Ninja" ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} .. && ninja && ninja install
+
+# build nginx (also building openssl)
+WORKDIR /opt/nginx-${NGINX_VERSION}
+RUN ./configure --prefix=${INSTALLDIR} \
+                --with-debug \
+                --with-http_ssl_module --with-openssl=/opt/openssl \
+                --without-http_gzip_module && \
+    make ${MAKE_DEFINES} && make install;
+
+# create openssl.cnf activating oqsprovider & setting default groups
+RUN mkdir -p ${OSSLDIR}/ssl && cp /opt/openssl/apps/openssl.cnf ${OSSLDIR}/ssl/ && sed -i "s/default = default_sect/default = default_sect\noqsprovider = oqsprovider_sect/g" ${OSSLDIR}/ssl/openssl.cnf && sed -i "s/\[default_sect\]/\[default_sect\]\nactivate = 1\n\[oqsprovider_sect\]\nactivate = 1\n/g" ${OSSLDIR}/ssl/openssl.cnf && sed -i "s/providers = provider_sect/providers = provider_sect\nssl_conf = ssl_sect\n\n\[ssl_sect\]\nsystem_default = system_default_sect\n\n\[system_default_sect\]\nGroups = \$ENV\:\:DEFAULT_GROUPS\n/g" ${OSSLDIR}/ssl/openssl.cnf && sed -i "s/HOME\t\t\t= ./HOME\t\t= .\nDEFAULT_GROUPS\t= ${DEFAULT_GROUPS}/g" ${OSSLDIR}/ssl/openssl.cnf
+
+# build oqsprovider
+WORKDIR /opt/oqs-provider
+
+RUN ln -s /opt/nginx/include/oqs ${OSSLDIR}/include && rm -rf build && cmake -DCMAKE_C_STANDARD_LIBRARIES="-ldl" -DOPENSSL_ROOT_DIR=${OSSLDIR} -DCMAKE_PREFIX_PATH=${INSTALLDIR} -S . -B build && cmake --build build && mkdir -p ${OSSLDIR}/lib64/ossl-modules && cp build/lib/oqsprovider.so ${OSSLDIR}/lib64/ossl-modules && rm -rf ${INSTALLDIR}/lib64
+
+WORKDIR ${INSTALLDIR}
+
+# Test/Utilize oqsprovider:
+    # generate CA key and cert
+    # generate server CSR
+    # generate server cert
+
+ENV PATH ${INSTALLDIR}/sbin:${OSSLDIR}/bin:$PATH
+# begin optimizing sizes:
+RUN strip ${OSSLDIR}/lib/*.a ${OSSLDIR}/lib64/ossl-modules/oqsprovider.so ${INSTALLDIR}/sbin/* ${INSTALLDIR}/sbin/*
+
+WORKDIR ${CONFIGDIR}
+
+#copies genconfig.py script
+COPY genconfig.py ${CONFIGDIR}
+COPY common.py ${CONFIGDIR}
+COPY ext-csr.conf ${CONFIGDIR}
+COPY index-template ${CONFIGDIR}
+COPY chromium-template ${CONFIGDIR}
+COPY success.htm ${CONFIGDIR}
+
+RUN python3 genconfig.py
+
+RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" index-base.html
+RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" chromium-base.html
+
+RUN rm -rf ${INSTALLDIR}/pki
+RUN rm -rf ${INSTALLDIR}/logs/*
+RUN cp -R pki ${INSTALLDIR}
+RUN cp interop.conf ${INSTALLDIR}
+RUN mkdir -p ${INSTALLDIR}/html
+RUN cp *.html ${INSTALLDIR}/html
+RUN cp rootca/CA.crt ${INSTALLDIR}/html
+RUN cp success.htm ${INSTALLDIR}/html/success.html
+RUN cp assignments.json ${INSTALLDIR}/html/
+
+# further optimize sizes:
+RUN rm ${OSSLDIR}/bin/*
+
+# second stage: Only create minimal image without build tooling and intermediate build results generated above:
+FROM ubuntu:focal-20230412
+# Take in global args
+ARG LIBOQS_BUILD_DEFINES
+ARG LIBOQS_VERSION
+ARG INSTALLDIR
+ARG SIG_ALG
+ARG BASEDIR
+ARG OSSLDIR=${BASEDIR}/openssl/.openssl
+
+LABEL version="2"
+
+ENV DEBIAN_FRONTEND noninteractive
+#RUN apk add pcre-dev
+RUN apt update && apt install -y libpcre3 libpcre3-dev
+
+# Only retain the ${*_PATH} contents in the final image
+COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}
+COPY --from=intermediate ${OSSLDIR} ${OSSLDIR}
+
+RUN tar czvf oqs-nginx-${LIBOQS_VERSION}.tgz ${BASEDIR}

--- a/nginx/fulltest-provider/Dockerfile
+++ b/nginx/fulltest-provider/Dockerfile
@@ -3,11 +3,11 @@
 # First: global build arguments:
 
 # liboqs build type variant; maximum portability of image:
-ARG LIBOQS_VERSION=0.8.0-rc1
+ARG LIBOQS_VERSION=0.8.0
 
 ARG OPENSSL_VERSION=master
 
-ARG OQS_PROVIDER_VERSION=main
+ARG OQS_PROVIDER_VERSION=0.5.0
 
 ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
@@ -23,7 +23,7 @@ ARG CONFIGDIR="/"
 ARG SIG_ALG="dilithium3"
 
 # defines the list of default groups to be activated in nginx-openssl config:
-ARG DEFAULT_GROUPS=x25519:x448:kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024
+ARG DEFAULT_GROUPS=x25519:x448:prime256v1:secp384r1:secp521r1:kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024
 
 # define the nginx version to include
 ARG NGINX_VERSION=1.24.0
@@ -48,7 +48,7 @@ ARG OSSLDIR=${BASEDIR}/openssl/.openssl
 
 ENV DEBIAN_FRONTEND noninteractive
 # Get all software packages required for builing all components (probably not all are really needed):
-RUN apt update && apt install -y sed libpcre3 libpcre3-dev libtool automake autoconf openssl libssl-dev build-essential git cmake astyle gcc ninja-build libssl-dev python3-pytest python3-psutil python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml valgrind wget
+RUN apt update && apt install -y sed libpcre3 libpcre3-dev libtool automake autoconf openssl libssl-dev build-essential git cmake astyle gcc ninja-build libssl-dev python3-pytest python3-psutil python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml valgrind wget scala
 
 # get OQS sources
 WORKDIR /opt
@@ -97,11 +97,17 @@ COPY ext-csr.conf ${CONFIGDIR}
 COPY index-template ${CONFIGDIR}
 COPY chromium-template ${CONFIGDIR}
 COPY success.htm ${CONFIGDIR}
+COPY OsslAlgParser.scala ${CONFIGDIR}
+
+RUN for i in 128 192 256; do echo "seclevel:$i"; OPENSSL_MODULES=${OSSLDIR}/lib64/ossl-modules /opt/openssl/apps/openssl list -provider oqsprovider -propquery oqsprovider.security_bits=$i -kem-algorithms; done | scala -nobootcp -nc OsslAlgParser.scala key_exchanges >> oqsprovider_alglist.py
+RUN for i in 128 192 256; do echo "seclevel:$i"; OPENSSL_MODULES=${OSSLDIR}/lib64/ossl-modules /opt/openssl/apps/openssl list -provider oqsprovider -propquery oqsprovider.security_bits=$i -signature-algorithms; done | scala -nobootcp -nc OsslAlgParser.scala signatures >> oqsprovider_alglist.py
 
 RUN python3 genconfig.py
 
 RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" index-base.html
+RUN sed -i "s/OQSPROVIDER_RELEASE/${OQS_PROVIDER_VERSION}/g" index-base.html
 RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" chromium-base.html
+RUN sed -i "s/OQSPROVIDER_RELEASE/${OQS_PROVIDER_VERSION}/g" chromium-base.html
 
 RUN rm -rf ${INSTALLDIR}/pki
 RUN rm -rf ${INSTALLDIR}/logs/*

--- a/nginx/fulltest-provider/OsslAlgParser.scala
+++ b/nginx/fulltest-provider/OsslAlgParser.scala
@@ -1,0 +1,43 @@
+// Parses the output of OpenSSL propquery security_bits from oqs-provider, 
+// and generates a sorted array of signatures/kems to be used by genconfig.py
+object OsslAlgParser {
+    import scala.annotation.tailrec
+
+    val providerName = "oqsprovider"
+
+    case class AlgSec(alg: String, seclevel: Int) {
+        override def toString: String = s"('$alg', $seclevel)"
+    }
+
+    val defaultSigs = List(AlgSec("ecdsap256", 0), AlgSec("rsa3072", 0))
+
+    @tailrec def readLines(line: String, in: List[AlgSec], seclevel: Option[Int]): List[AlgSec] = line match {
+        case null => 
+            in
+        case l if l.contains("seclevel") =>
+            val newSeclevel = Some(l.split(":")(1).toInt)
+            readLines(scala.io.StdIn.readLine(), in, newSeclevel)
+        case l =>
+            val out = line.split(" @ ").map(_.trim) match {
+                case i if i.length == 2 && i(1) == providerName => AlgSec(i(0), seclevel.get) :: in
+                case _ => in
+            }
+            readLines(scala.io.StdIn.readLine(), out, seclevel)
+    }
+
+    def main(args: Array[String]): Unit = {
+        if (args.length < 1) {
+            println("Usage: <key_exchanges/signatures>")
+            System.exit(0)
+        }
+        val kemsig = args(0)
+        val schemes = readLines(scala.io.StdIn.readLine(), List[AlgSec](), None)
+        val sorted = schemes.sortBy(i => {
+            val spl = i.alg.split("_")
+            (spl.length, spl.last, spl.head)
+        })
+        val fulllist = if (kemsig == "signatures") defaultSigs ++ sorted else sorted
+        val schemeStr = s"$kemsig = [\n${fulllist.map(i => s"  $i").mkString(",\n")}\n]"
+        println(schemeStr)
+    }
+}

--- a/nginx/fulltest-provider/README.md
+++ b/nginx/fulltest-provider/README.md
@@ -1,0 +1,37 @@
+# Scripts to generate OQS test server
+
+This folder contains all scripts to [build a QSC-enabled nginx server running on ubuntu](build-ubuntu.sh) as well as generating all configuration files for running an interoperability test server: Running [python3 genconfig.py](genconfig.py) generates a local/self-signed root CA, all QSC certificates signed by this root CA for the currently supported list of QSC algorithms and the required nginx-server configuration file for a server running at the configured TESTFQDN server address.
+
+*Note*: These scripts assume 
+- coherent definition of test server FQDN as TESTFQDN in `genconfig.py` and `ext-csr.conf` files: By default "test.openquantumsafe.org" is set.
+- presence of oqs-openssl common definitions file `common.py` (as stored at https://raw.githubusercontent.com/open-quantum-safe/oqs-provider/main/scripts/common.py).
+- presence of Docker on the build machine to run the build process, the guest OS needs to be able to mount host directories for Docker (i.e. on Linux, SELinux permissions might be needed).
+- presence on the target deploy server (i.e., at the machine designated at TESTFQDN) of a properly deployed [LetsEncrypt server certificate](https://letsencrypt.org/getting-started).
+
+By default, the server is built to a specific set of versions of `liboqs`, `openssl`, `oqs-provider` and `nginx`. These versions are encoded in `build-ubuntu.sh` and may be changed/upgraded there.
+
+### HOWTO
+
+#### Build and deploy test server
+
+On build machine run 
+
+```
+./build-ubuntu.sh
+scp oqs-nginx-{LIBOQS_VERSION}.tgz yourid@yourserver:yourpath
+```
+
+At 'yourserver' run:
+```
+cd / && tar xzvf yourpath/oqs-nginx-{LIBOQS_VERSION}.tgz
+cd /opt/nginx
+/opt/nginx/sbin/nginx -c interop.conf
+```
+
+Note that, the oqs-nginx-{LIBOQS_VERSION}.tgz package contains all required configuration files and QSC certificates. **Unpacking the archive may overwrite an existing installation's configuration files. Use with care on a live server.**
+
+#### Activation
+
+Execute `/opt/nginx/sbin/nginx -c /opt/nginx/interop.conf` to start the test server.
+
+*Note*: As the server many of ports, the server may need to be configured to permit this, e.g., using `ulimit -S -n 4096`.

--- a/nginx/fulltest-provider/build_ubuntu.sh
+++ b/nginx/fulltest-provider/build_ubuntu.sh
@@ -9,4 +9,4 @@
 docker build --no-cache -t oqs-nginx-fulltest-provider .
 
 # Copy tar from image
-docker cp $(docker create oqs-nginx-fulltest-provider:latest):oqs-nginx-0.8.0-rc1.tgz .
+docker cp $(docker create oqs-nginx-fulltest-provider:latest):oqs-nginx-0.8.0.tgz .

--- a/nginx/fulltest-provider/build_ubuntu.sh
+++ b/nginx/fulltest-provider/build_ubuntu.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Runs a docker build and packages the results as a tgz.
+
+# Get dependency (available after PR#..)
+#wget https://raw.githubusercontent.com/open-quantum-safe/oqs-provider/main/scripts/common.py
+
+# Build package
+docker build --no-cache -t oqs-nginx-fulltest-provider .
+
+# Copy tar from image
+docker cp $(docker create oqs-nginx-fulltest-provider:latest):oqs-nginx-0.8.0-rc1.tgz .

--- a/nginx/fulltest-provider/chromium-template
+++ b/nginx/fulltest-provider/chromium-template
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #eeeeee;
+}
+</style>
+<title>Open Quantum Safe interop test server for quantum-safe cryptography - Chromium overview</title>
+</head>
+<body>
+<h1 align=center>Open Quantum Safe interop test server for quantum-safe cryptography</h1>
+<h2> Purpose </h2>
+
+<p>This server is an NGINX instance enhanced with support for quantum-safe cryptography (QSC) using software packages provided by the <a href="https://www.openquantumsafe.org">Open Quantum Safe project</a> (OQS).</p>
+
+<p>In order to provide a means for clients to test interoperability with this QSC-enhanced software and the QSC algorithms contained it features separate ports for all QSC signature/key exchange algorithm combinations supported by the current OQS distribution. This page focuses on the algorithms supported by the OQS-enabled Chromium browser build.</p>
+
+<h2> Specification details </h2>
+
+<p>This nginx server supports</p>
+<ul>
+<li>the TLS1.3 specification with QSC enhancement as specified in <a href="https://tools.ietf.org/html/draft-ietf-tls-hybrid-design-06">https://tools.ietf.org/html/draft-ietf-tls-hybrid-design-06</a></li>
+<li>Code points/curve IDs of KEM algorithms are implemented with the highest numbers available for each algorithm listed <a href="https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md">here</a>. </li>
+<li>Code points/OIDs of SIG algorithms are implemented with the highest numbers available for each algorithm as listed <a href="https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md">here</a>. </li>
+</ul>
+
+<p>This corresponds to the OQS release version LIBOQS_RELEASE </p>
+
+<p>These specifications should not be taken as a standard, de facto and otherwise, and are subject to change at any time.</p>
+
+<p>Use the <a href="https://github.com/open-quantum-safe/oqs-demos/tree/main/chromium">OQS-enabled Chromium build</a> to access this web page. As per the limitations concerning supported algorithms as documented <a href="https://github.com/open-quantum-safe/boringssl/wiki/Implementation-Notes">here</a>, only the KEM algorithm combinations listed below will function (P256_BIKEL1, P256_FRODO640AES, P256_KYBER90S512, P256_NTRU_HPS2048509, P256_LIGHTSABER) and no hybrid signature algorithms are supported.
+
+<p>More details are available at <a href="https://github.com/open-quantum-safe/openssl/wiki/Integrating-PQC-into-TLS-1.3">Github</a>.</p>
+
+<p>An alternative view to <a href="index-base.html">all supported algorithms is available at this web page</a>.</p>
+
+<h4> Caveats </h4>
+
+<ol>
+<li>This test server by no means should be taken as containing production-ready software. See <a href="https://github.com/open-quantum-safe/openssl#limitations-and-security">disclaimer</a>. Its purpose is simply to provide a best-effort facility to allow anyone to "test-drive" QSC software packages including testing protocol level interoperability.</li>
+
+</ol>
+
+<h2> Certificates </h2>
+
+<p>Each test port provides TLS server authentication using a server certificate generated using the listed QSC-signature algorithm. All server certificates are signed by a common CA certificate using conventional (RSA) cryptography. This certificate is available for download <a href="CA.crt">here</a>.</p>
+
+<h2> List of all supported QSC Signature / Key Exchange algorithms for use by OQS-enabled Chromium</h2>
+
+<p>The list below provides links to the entry points of all OQS signature / key exchange algorithm combinations supported by the OQS-Chromium build.</p>
+
+<table>
+  <tr>
+    <th>Signature algorithm</th>
+    <th>Key exchange algorithm</th>
+    <th>Port</th>
+    <th>Link</th>
+  </tr>

--- a/nginx/fulltest-provider/chromium-template
+++ b/nginx/fulltest-provider/chromium-template
@@ -37,7 +37,7 @@ tr:nth-child(even) {
 <li>Code points/OIDs of SIG algorithms are implemented with the highest numbers available for each algorithm as listed <a href="https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md">here</a>. </li>
 </ul>
 
-<p>This corresponds to the OQS release version LIBOQS_RELEASE </p>
+<p>This corresponds to the OQS release version LIBOQS_RELEASE and oqs-provider version OQSPROVIDER_RELEASE.</p>
 
 <p>These specifications should not be taken as a standard, de facto and otherwise, and are subject to change at any time.</p>
 

--- a/nginx/fulltest-provider/common.py
+++ b/nginx/fulltest-provider/common.py
@@ -3,25 +3,7 @@ import subprocess
 import pathlib
 import psutil
 import time
-
-key_exchanges = [
-##### OQS_TEMPLATE_FRAGMENT_KEX_ALGS_START
-    # quantum-safe key exchanges
-    ('frodo640aes', 128),('frodo640shake', 128),('frodo976aes', 192),('frodo976shake', 192),('frodo1344aes', 256),('frodo1344shake', 256),('kyber512', 128),('kyber768', 192),('kyber1024', 256),('bikel1', 128),('bikel3', 192),('bikel5', 256),('hqc128', 128),('hqc192', 192),('hqc256', 256),
-    # quantum-safe + classical NIST key exchanges
-    ('p256_frodo640aes', 128),('p256_frodo640shake', 128),('p384_frodo976aes', 192),('p384_frodo976shake', 192),('p521_frodo1344aes', 256),('p521_frodo1344shake', 256),('p256_kyber512', 128),('p384_kyber768', 192),('p521_kyber1024', 256),('p256_bikel1', 128),('p384_bikel3', 192),('p521_bikel5', 256),('p256_hqc128', 128),('p384_hqc192', 192),('p521_hqc256', 256),
-    # quantum-safe + classical X key exchanges
-    ('x25519_frodo640aes', 128),('x25519_frodo640shake', 128),('x448_frodo976aes', 192),('x448_frodo976shake', 192),('x25519_kyber512', 128),('x448_kyber768', 192),('x25519_bikel1', 128),('x448_bikel3', 192),('x25519_hqc128', 128),('x448_hqc192', 192),    
-##### OQS_TEMPLATE_FRAGMENT_KEX_ALGS_END
-]
-signatures = [
-    ('ecdsap256', 0), ('rsa3072', 0),
-##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_START    # quantum-safe signatures
-    ('dilithium2', 128),('dilithium3', 192),('dilithium5', 256),('falcon512', 128),('falcon1024', 256),('sphincssha2128fsimple', 128),('sphincssha2128ssimple', 128),('sphincssha2192fsimple', 192),('sphincsshake128fsimple', 128),
-    # quantum-safe + classical signatures
-    ('p256_dilithium2', 128),('rsa3072_dilithium2', 128),('p384_dilithium3', 192),('p521_dilithium5', 256),('p256_falcon512', 128),('rsa3072_falcon512', 128),('p521_falcon1024', 256),('p256_sphincssha2128fsimple', 128),('rsa3072_sphincssha2128fsimple', 128),('p256_sphincssha2128ssimple', 128),('rsa3072_sphincssha2128ssimple', 128),('p384_sphincssha2192fsimple', 192),('p256_sphincsshake128fsimple', 128),('rsa3072_sphincsshake128fsimple', 128),
-##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_END
-]
+import oqsprovider_alglist
 
 SERVER_START_ATTEMPTS = 10
 

--- a/nginx/fulltest-provider/common.py
+++ b/nginx/fulltest-provider/common.py
@@ -1,0 +1,154 @@
+import os
+import subprocess
+import pathlib
+import psutil
+import time
+
+key_exchanges = [
+##### OQS_TEMPLATE_FRAGMENT_KEX_ALGS_START
+    # quantum-safe key exchanges
+    ('frodo640aes', 128),('frodo640shake', 128),('frodo976aes', 192),('frodo976shake', 192),('frodo1344aes', 256),('frodo1344shake', 256),('kyber512', 128),('kyber768', 192),('kyber1024', 256),('bikel1', 128),('bikel3', 192),('bikel5', 256),('hqc128', 128),('hqc192', 192),('hqc256', 256),
+    # quantum-safe + classical NIST key exchanges
+    ('p256_frodo640aes', 128),('p256_frodo640shake', 128),('p384_frodo976aes', 192),('p384_frodo976shake', 192),('p521_frodo1344aes', 256),('p521_frodo1344shake', 256),('p256_kyber512', 128),('p384_kyber768', 192),('p521_kyber1024', 256),('p256_bikel1', 128),('p384_bikel3', 192),('p521_bikel5', 256),('p256_hqc128', 128),('p384_hqc192', 192),('p521_hqc256', 256),
+    # quantum-safe + classical X key exchanges
+    ('x25519_frodo640aes', 128),('x25519_frodo640shake', 128),('x448_frodo976aes', 192),('x448_frodo976shake', 192),('x25519_kyber512', 128),('x448_kyber768', 192),('x25519_bikel1', 128),('x448_bikel3', 192),('x25519_hqc128', 128),('x448_hqc192', 192),    
+##### OQS_TEMPLATE_FRAGMENT_KEX_ALGS_END
+]
+signatures = [
+    ('ecdsap256', 0), ('rsa3072', 0),
+##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_START    # quantum-safe signatures
+    ('dilithium2', 128),('dilithium3', 192),('dilithium5', 256),('falcon512', 128),('falcon1024', 256),('sphincssha2128fsimple', 128),('sphincssha2128ssimple', 128),('sphincssha2192fsimple', 192),('sphincsshake128fsimple', 128),
+    # quantum-safe + classical signatures
+    ('p256_dilithium2', 128),('rsa3072_dilithium2', 128),('p384_dilithium3', 192),('p521_dilithium5', 256),('p256_falcon512', 128),('rsa3072_falcon512', 128),('p521_falcon1024', 256),('p256_sphincssha2128fsimple', 128),('rsa3072_sphincssha2128fsimple', 128),('p256_sphincssha2128ssimple', 128),('rsa3072_sphincssha2128ssimple', 128),('p384_sphincssha2192fsimple', 192),('p256_sphincsshake128fsimple', 128),('rsa3072_sphincsshake128fsimple', 128),
+##### OQS_TEMPLATE_FRAGMENT_SIG_ALGS_END
+]
+
+SERVER_START_ATTEMPTS = 10
+
+def run_subprocess(command, working_dir='.', expected_returncode=0, input=None, env=None):
+    """
+    Helper function to run a shell command and report success/failure
+    depending on the exit status of the shell command.
+    """
+
+    # Note we need to capture stdout/stderr from the subprocess,
+    # then print it, which pytest will then capture and
+    # buffer appropriately
+    print(working_dir + " > " + " ".join(command))
+    result = subprocess.run(
+        command,
+        input=input,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=working_dir,
+        env=env
+    )
+    if result.returncode != expected_returncode:
+        print(result.stdout.decode('utf-8'))
+        assert False, "Got unexpected return code {}".format(result.returncode)
+    return result.stdout.decode('utf-8')
+
+def start_server(ossl, test_artifacts_dir, sig_alg, worker_id):
+    command = [ossl, 's_server',
+                      '-cert', os.path.join(test_artifacts_dir, '{}_{}_srv.crt'.format(worker_id, sig_alg)),
+                      '-key', os.path.join(test_artifacts_dir, '{}_{}_srv.key'.format(worker_id, sig_alg)),
+                      '-CAfile', os.path.join(test_artifacts_dir, '{}_{}_CA.crt'.format(worker_id, sig_alg)),
+                      '-tls1_3',
+                      '-quiet',
+                      # On UNIX-like systems, binding to TCP port 0
+                      # is a request to dynamically generate an unused
+                      # port number.
+                      # TODO: Check if Windows behaves similarly
+                      '-accept', '0']
+
+    print(" > " + " ".join(command))
+    server = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    server_info = psutil.Process(server.pid)
+
+    # Try SERVER_START_ATTEMPTS times to see
+    # what port the server is bound to.
+    server_start_attempt = 1
+    while server_start_attempt <= SERVER_START_ATTEMPTS:
+        if server_info.connections():
+            break
+        else:
+            server_start_attempt += 1
+            time.sleep(2)
+    server_port = str(server_info.connections()[0].laddr.port)
+
+    # Check SERVER_START_ATTEMPTS times to see
+    # if the server is responsive.
+    server_start_attempt = 1
+    while server_start_attempt <= SERVER_START_ATTEMPTS:
+        result = subprocess.run([ossl, 's_client', '-connect', 'localhost:{}'.format(server_port)],
+                                input='Q'.encode(),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
+        if result.returncode == 0:
+            break
+        else:
+            server_start_attempt += 1
+            time.sleep(2)
+
+    if server_start_attempt > SERVER_START_ATTEMPTS:
+        raise Exception('Cannot start OpenSSL server')
+
+    return server, server_port
+
+def gen_keys(ossl, ossl_config, sig_alg, test_artifacts_dir, filename_prefix):
+    pathlib.Path(test_artifacts_dir).mkdir(parents=True, exist_ok=True)
+    if sig_alg == 'ecdsap256':
+        run_subprocess([ossl, 'ecparam',
+                              '-name', 'prime256v1',
+                              '-out', os.path.join(test_artifacts_dir, '{}_prime256v1.pem'.format(filename_prefix))])
+        run_subprocess([ossl, 'req', '-x509', '-new',
+                                     '-newkey', 'ec:{}'.format(os.path.join(test_artifacts_dir, '{}_prime256v1.pem'.format(filename_prefix))),
+                                     '-keyout', os.path.join(test_artifacts_dir, '{}_ecdsap256_CA.key'.format(filename_prefix)),
+                                     '-out', os.path.join(test_artifacts_dir, '{}_ecdsap256_CA.crt'.format(filename_prefix)),
+                                     '-nodes',
+                                         '-subj', '/CN=oqstest_CA',
+                                         '-days', '365',
+                                     '-config', ossl_config])
+        run_subprocess([ossl, 'req', '-new',
+                                     '-newkey', 'ec:{}'.format(os.path.join(test_artifacts_dir, '{}_prime256v1.pem'.format(filename_prefix))),
+                                     '-keyout', os.path.join(test_artifacts_dir, '{}_ecdsap256_srv.key'.format(filename_prefix)),
+                                     '-out', os.path.join(test_artifacts_dir, '{}_ecdsap256_srv.csr'.format(filename_prefix)),
+                                     '-nodes',
+                                         '-subj', '/CN=oqstest_server',
+                                     '-config', ossl_config])
+    else:
+        if sig_alg == 'rsa3072':
+            ossl_sig_alg_arg = 'rsa:3072'
+        else:
+            ossl_sig_alg_arg = sig_alg
+        run_subprocess([ossl, 'req', '-x509', '-new',
+                                     '-newkey', ossl_sig_alg_arg,
+                                     '-keyout', os.path.join(test_artifacts_dir, '{}_{}_CA.key'.format(filename_prefix, sig_alg)),
+                                     '-out', os.path.join(test_artifacts_dir, '{}_{}_CA.crt'.format(filename_prefix, sig_alg)),
+                                     '-nodes',
+                                         '-subj', '/CN=oqstest_CA',
+                                         '-days', '365',
+                                     '-config', ossl_config])
+        run_subprocess([ossl, 'req', '-new',
+                              '-newkey', ossl_sig_alg_arg,
+                              '-keyout', os.path.join(test_artifacts_dir, '{}_{}_srv.key'.format(filename_prefix, sig_alg)),
+                              '-out', os.path.join(test_artifacts_dir, '{}_{}_srv.csr'.format(filename_prefix, sig_alg)),
+                              '-nodes',
+                                  '-subj', '/CN=oqstest_server',
+                              '-config', ossl_config])
+
+    run_subprocess([ossl, 'x509', '-req',
+                                  '-in', os.path.join(test_artifacts_dir, '{}_{}_srv.csr'.format(filename_prefix, sig_alg)),
+                                  '-out', os.path.join(test_artifacts_dir, '{}_{}_srv.crt'.format(filename_prefix, sig_alg)),
+                                  '-CA', os.path.join(test_artifacts_dir, '{}_{}_CA.crt'.format(filename_prefix, sig_alg)),
+                                  '-CAkey', os.path.join(test_artifacts_dir, '{}_{}_CA.key'.format(filename_prefix, sig_alg)),
+                                  '-CAcreateserial',
+                                  '-days', '365'])
+
+    # also create pubkeys from certs for dgst verify tests:
+    env = os.environ
+    env["OPENSSL_CONF"]=os.path.join("apps", "openssl.cnf")
+    run_subprocess([ossl, 'req',
+                                  '-in', os.path.join(test_artifacts_dir, '{}_{}_srv.csr'.format(filename_prefix, sig_alg)),
+                                  '-pubkey', '-out', os.path.join(test_artifacts_dir, '{}_{}_srv.pubk'.format(filename_prefix, sig_alg)) ],
+                   env=env)

--- a/nginx/fulltest-provider/ext-csr.conf
+++ b/nginx/fulltest-provider/ext-csr.conf
@@ -1,0 +1,14 @@
+[req]
+distinguished_name = req_distinguished_name
+req_extensions = v3_req
+prompt = no
+
+[req_distinguished_name]
+CN = test.openquantumsafe.org
+
+[v3_req]
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = test.openquantumsafe.org

--- a/nginx/fulltest-provider/genconfig.py
+++ b/nginx/fulltest-provider/genconfig.py
@@ -1,6 +1,7 @@
 import common
 import os
 import json
+import oqsprovider_alglist
 
 # Script assumes nginx to have been built for this platform using build-ubuntu.sh
 
@@ -173,12 +174,12 @@ def gen_conf(filename, indexbasefilename, chromiumfilename):
      f.write("}\n")
 
      f.write("\n")
-     for sig in common.signatures:
+     for sig in oqsprovider_alglist.signatures:
         assignments[sig[0]]={}
         assignments[sig[0]]["*"]=port
         write_nginx_config(f, i, cf, port, sig, "*")
         port = port+1
-        for kex in common.key_exchanges:
+        for kex in oqsprovider_alglist.key_exchanges:
             # replace oqs_kem_default with X25519:
             if kex[0]=='oqs_kem_default':
                write_nginx_config(f, i, cf, port, sig, "X25519")
@@ -201,7 +202,7 @@ def gen_conf(filename, indexbasefilename, chromiumfilename):
 
 def main():
    # first generate certs for all supported sig algs:
-   for sig in common.signatures:
+   for sig in oqsprovider_alglist.signatures:
       gen_cert(sig)
    # now do conf and HTML files
    gen_conf("interop.conf", "index-base.html", "chromium-base.html")

--- a/nginx/fulltest-provider/genconfig.py
+++ b/nginx/fulltest-provider/genconfig.py
@@ -1,0 +1,209 @@
+import common
+import os
+import json
+
+# Script assumes nginx to have been built for this platform using build-ubuntu.sh
+
+############# Configuration section starting here
+
+# This is where the explanation HTML code is
+TEMPLATE_FILE="index-template"
+CHROMIUM_TEMPLATE_FILE="chromium-template"
+
+# This is where nginx is (to be) installed
+BASEPATH="/opt/nginx/"
+
+# This is the (relative to BASEPATH) path of all certificates
+PKIPATH="pki"
+
+# This is the port where all algorithms start to be present(ed)
+STARTPORT=6000
+
+# This is the local location of the OQS-enabled OpenSSL
+OPENSSL="/opt/openssl/apps/openssl"
+
+# This is the local OQS-OpenSSL config file
+OPENSSL_CNF="/opt/openssl/apps/openssl.cnf"
+
+# This is the fully-qualified domain name of the server to be set up
+# Ensure this is in sync with contents of ext-csr.conf file
+TESTFQDN="test.openquantumsafe.org"
+
+# This is the local folder where the root CA (key and cert) resides
+CAROOTDIR="/rootca"
+
+# This is the file containing the SIG/KEM/port assignments
+ASSIGNMENT_FILE="assignments.json"
+
+# The list of chromium-supported KEMs:
+# TODO: this list needs to be updated after a new Chromium build
+chromium_algs = ["p256_frodo640aes"]
+
+############# Functions starting here
+
+# Generate cert chain (server and CA for a given sig alg:
+# srv crt/key wind up in '<path>/<sigalg>_srv.crt|key
+def gen_cert(_sig_alg):
+   sig_alg = _sig_alg[0]
+   # first check whether we already have a root CA; if not create it
+   if not os.path.exists(CAROOTDIR):
+           os.mkdir(CAROOTDIR)
+           common.run_subprocess([OPENSSL, 'req', '-x509', '-new',
+                                     '-newkey', "rsa:4096",
+                                     '-keyout', os.path.join(CAROOTDIR, "CA.key"),
+                                     '-out', os.path.join(CAROOTDIR, "CA.crt"),
+                                     '-nodes',
+                                         '-subj', '/CN=oqstest_CA',
+                                         '-days', '500',
+                                     '-config', OPENSSL_CNF])
+           print("New root cert residing in %s." % (os.path.join(CAROOTDIR, "CA.crt")))
+
+   # first check whether we already have a PKI dir; if not create it
+   if not os.path.exists(PKIPATH):
+           os.mkdir(PKIPATH)
+
+   # now generate suitable server keys signed by that root; adapt algorithm names to std ossl 
+   if sig_alg == 'rsa3072':
+       ossl_sig_alg_arg = 'rsa:3072'
+   elif sig_alg == 'ecdsap256':
+       common.run_subprocess([OPENSSL, "ecparam", "-name", "prime256v1", "-out", os.path.join(PKIPATH, "prime256v1.pem")])
+       ossl_sig_alg_arg = 'ec:{}'.format(os.path.join(PKIPATH, "prime256v1.pem"))
+   else:
+       ossl_sig_alg_arg = sig_alg
+   # generate server key and CSR
+   common.run_subprocess([OPENSSL, 'req', '-new',
+                              '-newkey', ossl_sig_alg_arg,
+                              '-keyout', os.path.join(PKIPATH, '{}_srv.key'.format(sig_alg)),
+                              '-out', os.path.join(PKIPATH, '{}_srv.csr'.format(sig_alg)),
+                              '-nodes',
+                              '-subj', '/CN='+TESTFQDN,
+                              '-config', OPENSSL_CNF])
+   # generate server cert off common root
+   common.run_subprocess([OPENSSL, 'x509', '-req',
+                                  '-in', os.path.join(PKIPATH, '{}_srv.csr'.format(sig_alg)),
+                                  '-out', os.path.join(PKIPATH, '{}_srv.crt'.format(sig_alg)),
+                                  '-CA', os.path.join(CAROOTDIR, 'CA.crt'),
+                                  '-CAkey', os.path.join(CAROOTDIR, 'CA.key'),
+                                  '-CAcreateserial',
+                                  '-extfile', 'ext-csr.conf', 
+                                  '-extensions', 'v3_req',
+                                  '-days', '365'])
+
+def write_nginx_config(f, i, cf, port, _sig, k):
+           sig = _sig[0]
+           f.write("server {\n")
+           f.write("    listen              0.0.0.0:"+str(port)+" ssl;\n\n")
+           f.write("    server_name         "+TESTFQDN+";\n")
+           f.write("    access_log          "+BASEPATH+"logs/"+sig+"-access.log;\n")
+           f.write("    error_log           "+BASEPATH+"logs/"+sig+"-error.log;\n\n")
+           f.write("    ssl_certificate     "+BASEPATH+PKIPATH+"/"+sig+"_srv.crt;\n")
+           f.write("    ssl_certificate_key "+BASEPATH+PKIPATH+"/"+sig+"_srv.key;\n\n")
+           f.write("    ssl_protocols       TLSv1.3;\n")
+           if k!="*" :  
+              f.write("    ssl_ecdh_curve      "+k+";\n")
+           f.write("    location / {\n")
+           f.write("            ssi    on;\n")
+           if k!="*" :  
+              f.write("            set    $oqs_alg_name \""+sig+"-"+k+"\";\n")
+           f.write("            root   html;\n")
+           f.write("            index  success.html;\n")
+           f.write("    }\n\n")
+
+           f.write("}\n\n")
+           # activate for more boring links-only display:
+           #i.write("<li><a href=https://"+TESTFQDN+":"+str(port)+">"+sig+"/"+k+" ("+str(port)+")</a></li>\n")
+           #if k in chromium_algs:
+           #   cf.write("<li><a href=https://"+TESTFQDN+":"+str(port)+">"+sig+"/"+k+" ("+str(port)+")</a></li>\n")
+
+           # deactivate if you don't like tables:
+           i.write("<tr><td>"+sig+"</td><td>"+k+"</td><td>"+str(port)+"</td><td><a href=https://"+TESTFQDN+":"+str(port)+">"+sig+"/"+k+"</a></td></tr>\n")
+           if k in chromium_algs and not ("_" in sig and (sig.startswith("p") or (sig.startswith("rsa")))):
+               cf.write("<tr><td>"+sig+"</td><td>"+k+"</td><td>"+str(port)+"</td><td><a href=https://"+TESTFQDN+":"+str(port)+">"+sig+"/"+k+"</a></td></tr>\n")
+
+
+# generates nginx config
+def gen_conf(filename, indexbasefilename, chromiumfilename):
+   port = STARTPORT
+   assignments={}
+   i = open(indexbasefilename, "w")
+   cf = open(chromiumfilename, "w")
+   # copy baseline templates
+   with open(TEMPLATE_FILE, "r") as tf:
+     for line in tf:
+       i.write(line)
+   with open(CHROMIUM_TEMPLATE_FILE, "r") as ctf:
+     for line in ctf:
+       cf.write(line)
+
+   with open(filename, "w") as f:
+     # baseline config
+     f.write("worker_processes  auto;\n")
+     f.write("worker_rlimit_nofile  10000;\n")
+     f.write("events {\n")
+     f.write("    worker_connections  32000;\n")
+     f.write("}\n")
+     f.write("\n")
+     f.write("http {\n")
+     f.write("    include       conf/mime.types;\n");
+     f.write("    default_type  application/octet-stream;\n")
+     f.write("    keepalive_timeout  65;\n\n")
+     # plain server for base information
+     f.write("server {\n")
+     f.write("    listen      80;\n")
+     f.write("    server_name "+TESTFQDN+";\n")
+     f.write("    access_log  /opt/nginx/logs/80-access.log;\n")
+     f.write("    error_log   /opt/nginx/logs/80-error.log;\n\n")
+     f.write("    location / {\n")
+     f.write("            root   html;\n")
+     f.write("            index  "+indexbasefilename+";\n")
+     f.write("    }\n")
+     f.write("}\n")
+     f.write("server {\n")
+     f.write("    listen      443 ssl;\n")
+     f.write("    server_name "+TESTFQDN+";\n")
+     f.write("    access_log  /opt/nginx/logs/443-access.log;\n")
+     f.write("    error_log   /opt/nginx/logs/443-error.log;\n\n")
+     f.write("    ssl_certificate     /etc/letsencrypt/live/"+TESTFQDN+"/fullchain.pem;\n")
+     f.write("    ssl_certificate_key /etc/letsencrypt/live/"+TESTFQDN+"/privkey.pem;\n\n")
+     f.write("    ssl_protocols       TLSv1.2 TLSv1.3;\n")
+     f.write("    location / {\n")
+     f.write("            root   html;\n")
+     f.write("            index  "+indexbasefilename+";\n")
+     f.write("    }\n")
+     f.write("}\n")
+
+     f.write("\n")
+     for sig in common.signatures:
+        assignments[sig[0]]={}
+        assignments[sig[0]]["*"]=port
+        write_nginx_config(f, i, cf, port, sig, "*")
+        port = port+1
+        for kex in common.key_exchanges:
+            # replace oqs_kem_default with X25519:
+            if kex[0]=='oqs_kem_default':
+               write_nginx_config(f, i, cf, port, sig, "X25519")
+               assignments[sig[0]][kex[0]]=port
+               port = port+1
+            elif kex[1] == sig[1] or sig[1] == 0: # only add if the sig and kex security levels match or sig[1]==0 (rsa/ecdsa)
+               write_nginx_config(f, i, cf, port, sig, kex[0])
+               assignments[sig[0]][kex[0]]=port
+               port = port+1
+     f.write("}\n")
+   # deactivate if you don't like tables:
+   i.write("</table>\n")
+   i.write("</body></html>\n")
+   i.close()
+   cf.write("</table>\n")
+   cf.write("</body></html>\n")
+   cf.close()
+   with open(ASSIGNMENT_FILE, 'w') as outfile:
+      json.dump(assignments, outfile)
+
+def main():
+   # first generate certs for all supported sig algs:
+   for sig in common.signatures:
+      gen_cert(sig)
+   # now do conf and HTML files
+   gen_conf("interop.conf", "index-base.html", "chromium-base.html")
+
+main()

--- a/nginx/fulltest-provider/index-template
+++ b/nginx/fulltest-provider/index-template
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+table {
+  font-family: arial, sans-serif;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+td, th {
+  border: 1px solid #dddddd;
+  text-align: left;
+  padding: 8px;
+}
+
+tr:nth-child(even) {
+  background-color: #eeeeee;
+}
+</style>
+<title>Open Quantum Safe interop test server for quantum-safe cryptography</title>
+</head>
+<body>
+<h1 align=center>Open Quantum Safe interop test server for quantum-safe cryptography</h1>
+<h2> Purpose </h2>
+
+<p>This server is an NGINX instance enhanced with support for quantum-safe cryptography (QSC) using software packages provided by the <a href="https://www.openquantumsafe.org">Open Quantum Safe project</a> (OQS).</p>
+
+<p>In order to provide a means for clients to test interoperability with this QSC-enhanced software and the QSC algorithms contained it features separate ports for all QSC signature/key exchange algorithm combinations supported by the current OQS distribution.</p>
+
+<h2> Specification details </h2>
+
+<p>This nginx server supports</p>
+<ul>
+<li>the TLS1.3 specification with QSC enhancement as specified in <a href="https://tools.ietf.org/html/draft-ietf-tls-hybrid-design-06">https://tools.ietf.org/html/draft-ietf-tls-hybrid-design-06</a>.</li>
+<li>Code points/curve IDs of KEM algorithms are implemented with the highest numbers available for each algorithm listed <a href="https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md">here</a>. </li>
+<li>Code points/OIDs of SIG algorithms are implemented with the highest numbers available for each algorithm as listed <a href="https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md">here</a>. </li>
+</ul>
+
+<p>This corresponds to the OQS release version LIBOQS_RELEASE. </p>
+
+<p>These specifications should not be taken as a standard, de facto and otherwise, and are subject to change at any time.</p>
+
+<p>More details are available at <a href="https://github.com/open-quantum-safe/openssl/wiki/Integrating-PQC-into-TLS-1.3">Github</a>.</p>
+
+<h4> Caveats </h4>
+
+<ol>
+<li>This test server by no means should be taken as containing production-ready software. See <a href="https://github.com/open-quantum-safe/openssl#limitations-and-security">disclaimer</a>. Its purpose is simply to provide a best-effort facility to allow anyone to "test-drive" QSC software packages including testing protocol level interoperability.</li>
+
+<li>When using the <a href="https://github.com/open-quantum-safe/oqs-demos/tree/main/chromium">OQS-enabled Chromium build</a> to access this web site, be aware of the limitations concerning supported algorithms as documented <a href="https://github.com/open-quantum-safe/boringssl/wiki/Implementation-Notes">here</a>. <!--Therefore, only the following hybrid KEM algorithms will work: P256_BIKEL1, P256_FRODO640AES, P256_KYBER90S512, P256_NTRU_HPS2048509, P256_LIGHTSABER. Using the browser's search function ("CTRL-F") for these algorithm names on this page provides quick access to the ports running these algorithms. Also note that OQS-Chromium does not support any hybrid signature algorithms. Alternatively, use the <a href="chromium-base.html">OQS-Chromium algorithm list page</a> to access these algorithms.</li>-->
+<li>When using the <a href="https://github.com/open-quantum-safe/oqs-demos/tree/main/epiphany">OQS-enabled GNOME Web/epiphany browser</a> to access this web site, all ports can be accessed, provided the browser is suitably started enabling the algorithms of interest. Please <a href="https://hub.docker.com/repository/docker/openquantumsafe/epiphany">read the documentation</a> how to do this.
+</ol>
+
+<h2> Certificates </h2>
+
+<p>Each test port provides TLS server authentication using a server certificate generated using the listed QSC-signature algorithm. All server certificates are signed by a common CA certificate using conventional (RSA) cryptography. This certificate is available for download <a href="CA.crt">here</a>.</p>
+
+<h2> Testing procedure </h2>
+
+<p>While we cannot prescribe how this test infrastructure is used we can show how it can be utilized using the OQS software made available ready-build at <a href="https://hub.docker.com/u/openquantumsafe">Docker Hub</a> adding suggestions how other QSC-TLS implementations could check interoperability.</p>
+
+<ol>
+<li>If not already done, download the test CA certificate from <a href="CA.crt">here</a> to the directory you want to execute your tests from.</li>
+<li>Select the algorithm combination to be tested from the list below. Assume this is <i>sig/kex (port)</i>.</li>
+<li>Connect to the corresponding port with a QSC-enabled client side software, e.g., curl. Using a ready-made docker image this could be facilitated by running <br><pre>docker run -v `pwd`:/ca -it openquantumsafe/curl:LIBOQS_RELEASE curl --cacert /ca/CA.crt https://test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre>Be sure to insert the <i>port</i> and <i>kex</i> values chosen above.<br>The test will be successful if a web page indicating successful connection establishment (and display of the OQS algorithm combination configured as well as the client-supported key exchange mechanism) is received.</li>
+</ol>
+
+<p>Notes: </p>
+<ol>
+<li>The instructions above assume a local installation of <a href="https://www.docker.com/get-started">Docker</a>. </li>
+<li><p>Another equally valid approach would be to build all required software from source and then execute it locally. Examples for this can be found in <a href="https://github.com/open-quantum-safe/oqs-demos">the OQS Github repository</a>.</p>
+<p>In this way, you could for example verify correct operation of all components using openssl's <i>s_client</i> function by running <pre>echo "GET /" | openssl s_client -CAfile CA.crt --connect test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre> Again, values for <i>port</i> and <i>kex</i> must be suitably set.</p></li>
+<li>Using "openssl s_client" has the additional benefit that it also displays the actual algorithms utilized: <i>Server Temp Key</i> describes the key exchange algorithm and <i>Peer signature type</i> the signature algorithm actually used.</li> 
+<li>The OQS docker hub containers also provide a ready-made QSC-openssl distribution facilitating this test: You can do this for example with this command: <pre>docker run -v `pwd`:/ca -it openquantumsafe/curl:LIBOQS_RELEASE openssl s_client --connect test.openquantumsafe.org:6000 -CAfile /ca/CA.crt </pre> Then issue the <tt>GET /</tt> command on the command line to retrieve an information page.</li>
+<li>The OQS docker images are pre-loaded with the test CA certificate which allow simplified testing bypassing the need to first obtain the test CA certificate and mounting this into the docker image. Therefore, testing a specific algorithm can be done simply without any preparation by running <br><pre>docker run -it openquantumsafe/curl:LIBOQS_RELEASE curl --cacert /opt/oqssa/oqs-testca.pem https://test.openquantumsafe.org:<i>port</i> --curves <i>kex</i></pre></li>
+</ol>
+
+<h2> List of all supported QSC Signature / Key Exchange algorithms </h2>
+
+<p>The list below provides links to the entry points of all OQS signature / key exchange algorithm combinations supported.</p>
+
+<p>For automated testing, a JSON file encoding all available SIG/KEM combinations and the respective ports where they can be found is <a href="assignments.json">available for download here</a>. <i>We explicitly want to warn that algorithm/port combinations are subject to change. Be sure to download the most current JSON file before testing.</i></p>
+
+
+<table>
+  <tr>
+    <th>Signature algorithm</th>
+    <th>Key exchange algorithm</th>
+    <th>Port</th>
+    <th>Link</th>
+  </tr>

--- a/nginx/fulltest-provider/index-template
+++ b/nginx/fulltest-provider/index-template
@@ -37,7 +37,7 @@ tr:nth-child(even) {
 <li>Code points/OIDs of SIG algorithms are implemented with the highest numbers available for each algorithm as listed <a href="https://github.com/open-quantum-safe/oqs-provider/blob/main/ALGORITHMS.md">here</a>. </li>
 </ul>
 
-<p>This corresponds to the OQS release version LIBOQS_RELEASE. </p>
+<p>This corresponds to the OQS release version LIBOQS_RELEASE and oqs-provider version OQSPROVIDER_RELEASE.</p>
 
 <p>These specifications should not be taken as a standard, de facto and otherwise, and are subject to change at any time.</p>
 

--- a/nginx/fulltest-provider/success.htm
+++ b/nginx/fulltest-provider/success.htm
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Open Quantum Safe interop test server for quantum-safe cryptography</title>
+</head>
+<body>
+<h1 align=center>
+Successfully connected using
+<!--# echo var="oqs_alg_name" default="unknown" -->
+!
+</h1>
+
+Client-side KEM algorithm(s) indicated:
+<!--# echo var="ssl_curves" default="no" -->
+</body>

--- a/nginx/fulltest-provider/testrun.py
+++ b/nginx/fulltest-provider/testrun.py
@@ -1,0 +1,28 @@
+import json
+import sys
+import subprocess
+import os
+
+# Parameter checks already done in shellscript
+
+with open("assignments.json", "r") as f:
+   jsoncontents = f.read();
+
+assignments = json.loads(jsoncontents)
+for sig in assignments:
+    print("Testing %s:" % (sig))
+    for kem in assignments[sig]:
+       # assemble testing command
+       cmd = "docker run -v "+os.path.abspath(os.getcwd())+"/ca:/ca -it "+sys.argv[1]+" curl --cacert /ca/CA.crt https://test.openquantumsafe.org:"+str(assignments[sig][kem])
+       if kem!="*": # don't prescribe KEM
+          cmd=cmd+" --curves "+kem
+       dockerrun = subprocess.run(cmd.split(" "),stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+       if dockerrun.returncode != 0 or not (b"Successfully" in dockerrun.stdout):
+          print("Error executing %s (Output: %s). Terminating." % (cmd, dockerrun.stdout))
+          exit(1)
+       else:
+          print("    Tested KEM %s successfully." % (kem))
+    print("  Successfully concluded testing "+sig) 
+print("All tests successfully passed.")
+
+

--- a/nginx/fulltest-provider/testrun.sh
+++ b/nginx/fulltest-provider/testrun.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Arg1 is docker image to use as client
+if [ "$#" -ne 1 ]; then
+    echo "Usage: ${0} <docker-image name>. Exiting."
+    exit 1
+fi
+
+# prepare test
+rm -rf ca assignments.json* 
+mkdir ca
+# pull current CA cert
+cd ca
+wget https://test.openquantumsafe.org/CA.crt
+cd ..
+
+# pull list of algs/ports
+wget https://test.openquantumsafe.org/assignments.json
+
+# execute test
+python3 testrun.py ${1}


### PR DESCRIPTION
Adds docker-based build for test server package, using ubuntu docker base.

Difference to previous test server config: only (pq-)signatures and kems with matching security levels are configured (exception are the baseline rsa/ecdsa signatures).

Note: The PR currently includes a common.py, which can be automatically loaded once https://github.com/open-quantum-safe/oqs-provider/pull/173 is merged.