### PR TITLE
tag github docker images

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,4 +1,4 @@
-name: 
+name: Docker images
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
           - linux/amd64
 #          - linux/arm/v6
 #          - linux/arm/v7
-#          - linux/arm64
+          - linux/arm64
     steps:
       -
         name: Checkout
@@ -55,8 +55,6 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
-#          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache
-#          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache,mode=max
       -
         name: Export digest
         run: |
@@ -93,6 +91,9 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=sha,enable=true,prefix=commit-
+            type=raw,value=latest,enable=true
       -
         name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![GitHub actions](https://github.com/open-quantum-safe/oqs-demos/actions/workflows/linux.yml/badge.svg)](https://github.com/open-quantum-safe/oqs-demos/actions/workflows/linux.yml)
 [![open-quantum-safe](https://circleci.com/gh/open-quantum-safe/oqs-demos.svg?style=svg)](https://app.circleci.com/pipelines/github/open-quantum-safe/oqs-demos)
 
 oqs-demos


### PR DESCRIPTION
- Properly tag docker images: "...:latest" and "...:-commit-hash" in preparation for automated release-tagging
- Also activates ARM64 x-build
- Also adds github CI status to README