### PR TITLE
Update unbound DNS for openssl 3.x.x

### DIFF
--- a/unbound/Dockerfile-getdns
+++ b/unbound/Dockerfile-getdns
@@ -1,54 +1,62 @@
-FROM ubuntu:18.04
-##necessary lib
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y \
-      cmake \ 
-      gcc \ 
-      libtool \ 
-      libssl-dev \
-      make \ 
-      ninja-build \ 
-      git
+# Multi-stage build: First the full builder image:
 
-##installation of openssl with oqs 
-##############################################################################
-WORKDIR /root
-RUN git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl.git openssl
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
 
-RUN cd openssl && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git \
-      && cd liboqs \
-      && mkdir build && cd build \
-      && cmake -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/root/openssl/oqs .. \
-      && ninja && ninja install
+# Default KEM algorithms; can be set to any listed at https://github.com/open-quantum-safe/oqs-provider#algorithms
+ARG DEFAULT_GROUPS="kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024"
 
-WORKDIR /root
-RUN cd openssl \
- && ./Configure shared linux-x86_64 -lm \
- && ldconfig \
- && make && make install
+FROM alpine:3.17 as intermediate
+# Take in all global args
+ARG INSTALLDIR
+
+ARG DEFAULT_GROUPS
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apk update && apk upgrade
+
+# Get all software packages required for builing all components:
+RUN apk add build-base linux-headers \
+            libtool automake autoconf cmake ninja \
+            make \
+            openssl openssl-dev \
+            git wget
+
+# get all sources
+WORKDIR /opt
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
+    git clone --depth 1 --branch master https://github.com/openssl/openssl.git && \
+    git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
+
+# build liboqs
+WORKDIR /opt/liboqs
+RUN mkdir build && cd build && cmake -G"Ninja" .. -DOQS_DIST_BUILD=ON -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
+
+# build OpenSSL3
+WORKDIR /opt/openssl
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib64" ./config shared --prefix=${INSTALLDIR} && \
+    make && make install_sw install_ssldirs;
+
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# build & install provider (and activate by default)
+WORKDIR /opt/oqs-provider
+RUN ln -s ../openssl . && cmake -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${INSTALLDIR} -S . -B _build && cmake --build _build  && cp _build/lib/oqsprovider.so ${INSTALLDIR}/lib64/ossl-modules && sed -i "s/default = default_sect/default = default_sect\noqsprovider = oqsprovider_sect/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/\[default_sect\]/\[default_sect\]\nactivate = 1\n\[oqsprovider_sect\]\nactivate = 1\n/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/providers = provider_sect/providers = provider_sect\nssl_conf = ssl_sect\n\n\[ssl_sect\]\nsystem_default = system_default_sect\n\n\[system_default_sect\]\nGroups = \$ENV\:\:DEFAULT_GROUPS\n/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/\# Use this in order to automatically load providers/\# Set default KEM groups if not set via environment variable\nKDEFAULT_GROUPS = $DEFAULT_GROUPS\n\n# Use this in order to automatically load providers/g" /opt/oqssa/ssl/openssl.cnf && sed -i "s/HOME\t\t\t= ./HOME\t\t= .\nDEFAULT_GROUPS\t= ${DEFAULT_GROUPS}/g" /opt/oqssa/ssl/openssl.cnf
+
 
 ##installation of getdns && other dependency
 ##############################################################################
-RUN apt update && apt install -y \
-      wget build-essential libunbound-dev libidn2-dev libssl-dev cmake libevent-dev libev-dev  libuv1-dev autoconf check 
-      
-RUN git clone https://github.com/libuv/libuv.git && \
-	cd libuv && \
-	sh autogen.sh && \
-	 ./configure && \
-	make install
 
-##getdns to query unbound with tls encryption
-RUN apt install -y getdns-utils   
+RUN apk add cmake  --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
-##force kex to be "p384_kyber768:X25519"
-ENV TLS_DEFAULT_GROUPS="p384_kyber768:X25519"
-
-   
-#RUN wget --no-check-certificate -O getdns.tar.gz  https://getdnsapi.net/releases/getdns-1-7-2/getdns-1.7.2.tar.gz && \
-#	tar xzf getdns.tar.gz && \
-#	cd getdns-1.7.2 && \
-#	mkdir build && cd build && \
-#	ldconfig && \
-#	cmake .. && \
-#	make install 
+WORKDIR /opt
+RUN apk add --update alpine-sdk libidn2-dev unbound-dev openssl-dev libev-dev libuv-dev check-dev yaml-dev && \
+      export OPENSSL_ROOT_DIR=/opt/oqssa && \
+      wget https://getdnsapi.net/releases/getdns-1-7-3/getdns-1.7.3.tar.gz && \
+      tar xvf getdns-1.7.3.tar.gz && \
+      cd getdns-1.7.3/ && \
+      mkdir build && cd build && cmake .. && \
+      make && \
+      make install

--- a/unbound/Dockerfile-unbound
+++ b/unbound/Dockerfile-unbound
@@ -1,46 +1,75 @@
-FROM ubuntu:18.04
-##necessary lib 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install -y \
-      cmake \ 
-      gcc \ 
-      libtool \ 
-      libssl-dev \
-      make \ 
-      ninja-build \ 
-      git
+# Multi-stage build: First the full builder image:
 
-##installation of openssl with oqs
-##############################################################################
-WORKDIR /root
-RUN git clone --depth 1 --branch OQS-OpenSSL_1_1_1-stable https://github.com/open-quantum-safe/openssl.git openssl
+# Default location where all binaries wind up:
+ARG INSTALLDIR=/opt/oqssa
 
-RUN cd openssl && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs.git \
-      && cd liboqs \
-      && mkdir build && cd build \
-      && cmake -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/root/openssl/oqs .. \
-      && ninja && ninja install
+# Default KEM algorithms; can be set to any listed at https://github.com/open-quantum-safe/oqs-provider#algorithms
+ARG DEFAULT_GROUPS="kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024"
 
-WORKDIR /root
-RUN cd openssl \
- && ./Configure shared linux-x86_64 -lm \
- && make && make install
+FROM alpine:3.11 as intermediate
+# Take in all global args
+ARG INSTALLDIR
+
+ARG DEFAULT_GROUPS
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apk update && apk upgrade
+
+# Get all software packages required for builing all components:
+RUN apk add build-base linux-headers \
+            libtool automake autoconf cmake ninja \
+            make \
+            openssl openssl-dev \
+            git wget
+
+# get all sources
+WORKDIR /opt
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs && \
+    git clone --depth 1 --branch master https://github.com/openssl/openssl.git && \
+    git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
+
+# build liboqs
+WORKDIR /opt/liboqs
+RUN mkdir build && cd build && cmake -G"Ninja" .. -DOQS_DIST_BUILD=ON -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
+
+# build OpenSSL3
+WORKDIR /opt/openssl
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR}/lib64" ./config shared --prefix=${INSTALLDIR} && \
+    make && make install_sw install_ssldirs;
+
+# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+ENV PATH="${INSTALLDIR}/bin:${PATH}"
+
+# build & install provider (and activate by default)
+WORKDIR /opt/oqs-provider
+RUN ln -s ../openssl . && \
+cmake -DOPENSSL_ROOT_DIR=${INSTALLDIR} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${INSTALLDIR} -S . -B _build && \
+cmake --build _build  && cp _build/lib/oqsprovider.so ${INSTALLDIR}/lib64/ossl-modules && \
+sed -i "s/default = default_sect/default = default_sect\noqsprovider = oqsprovider_sect/g" /opt/oqssa/ssl/openssl.cnf && \
+sed -i "s/\[default_sect\]/\[default_sect\]\nactivate = 1\n\[oqsprovider_sect\]\nactivate = 1\n/g" /opt/oqssa/ssl/openssl.cnf && \
+sed -i "s/providers = provider_sect/providers = provider_sect\nssl_conf = ssl_sect\n\n\[ssl_sect\]\nsystem_default = \
+        system_default_sect\n\n\[system_default_sect\]\nGroups = \$ENV\:\:DEFAULT_GROUPS\n/g" /opt/oqssa/ssl/openssl.cnf && \
+sed -i "s/\# Use this in order to automatically load providers/\# Set default KEM groups if not set via environment variable\nKDEFAULT_GROUPS = \
+        $DEFAULT_GROUPS\n\n# Use this in order to automatically load providers/g" /opt/oqssa/ssl/openssl.cnf && \
+sed -i "s/HOME\t\t\t= ./HOME\t\t= .\nDEFAULT_GROUPS\t= ${DEFAULT_GROUPS}/g" /opt/oqssa/ssl/openssl.cnf
+
 
 ##installation of necessary lib for unbound
 ##############################################################################
-RUN apt update && apt install -y \
-    wget \
+RUN apk update && apk add \
     tar \
-    libevent-dev \
+    libevent \
     tar \
     autoconf \
-    libldns-dev \
-    libevent-dev \
+    ldns \
+    libevent \
     ca-certificates \
-    libexpat1 \
-    libexpat1-dev \
+    expat-dev \
     flex \
     bison
+
+RUN openssl version -a
 
 ##installation of unbound
 ENV UNBOUND_DOWNLOAD_URL https://www.unbound.net/downloads/unbound-latest.tar.gz
@@ -51,11 +80,10 @@ RUN set -x && \
     tar xzf unbound.tar.gz  && \
     rm -f unbound.tar.gz && \ 
     cd */ && \
-    groupadd unbound && \
-    useradd -g unbound -s /etc -d /dev/null unbound && \
+    addgroup unbound && \
+    adduser -D -G unbound -s /etc -h /dev/null unbound && \
     ./configure --prefix=/opt/unbound \
-    --with-username=unbound --disable-ecdsa --with-pthreads --with-ssl=/usr/local && \
-    ldconfig && \
+    --with-username=unbound --disable-ecdsa --with-pthreads --with-ssl=/opt/oqssa && \
     make install && \
     mv /opt/unbound/etc/unbound/unbound.conf /opt/unbound/etc/unbound/unbound.conf.example && \
     rm -fr /opt/unbound/share/man && \


### PR DESCRIPTION
this update used the latest openssl oqs provider as recommended.