### PR TITLE
Update test.openquantumsafe.org & resolve some issues

### DIFF
--- a/nginx/fulltest-provider/Dockerfile
+++ b/nginx/fulltest-provider/Dockerfile
@@ -7,7 +7,7 @@ ARG LIBOQS_VERSION=0.8.0
 
 ARG OPENSSL_VERSION=master
 
-ARG OQS_PROVIDER_VERSION=0.5.0
+ARG OQS_PROVIDER_VERSION=0.5.1
 
 ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
@@ -26,10 +26,10 @@ ARG SIG_ALG="dilithium3"
 ARG DEFAULT_GROUPS=x25519:x448:prime256v1:secp384r1:secp521r1:kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024
 
 # define the nginx version to include
-ARG NGINX_VERSION=1.24.0
+ARG NGINX_VERSION=1.25.1
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
-ARG MAKE_DEFINES="-j128"
+ARG MAKE_DEFINES="-j"
 
 FROM ubuntu:focal-20230412 as intermediate
 # Take in global args
@@ -48,7 +48,7 @@ ARG OSSLDIR=${BASEDIR}/openssl/.openssl
 
 ENV DEBIAN_FRONTEND noninteractive
 # Get all software packages required for builing all components (probably not all are really needed):
-RUN apt update && apt install -y sed libpcre3 libpcre3-dev libtool automake autoconf openssl libssl-dev build-essential git cmake astyle gcc ninja-build libssl-dev python3-pytest python3-psutil python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml valgrind wget scala
+RUN apt update && apt install -y sed libpcre3 libpcre3-dev libtool automake autoconf openssl libssl-dev build-essential git cmake astyle gcc ninja-build libssl-dev python3-pytest python3-psutil python3-pytest-xdist unzip xsltproc doxygen graphviz python3-yaml valgrind wget scala patch
 
 # get OQS sources
 WORKDIR /opt
@@ -61,8 +61,10 @@ RUN git clone --depth 1 --branch ${LIBOQS_VERSION} https://github.com/open-quant
 WORKDIR /opt/liboqs
 RUN mkdir build && cd build && cmake -G"Ninja" ${LIBOQS_BUILD_DEFINES} -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} .. && ninja && ninja install
 
+COPY ngx_event_openssl.patch /opt/nginx-${NGINX_VERSION}
 # build nginx (also building openssl)
 WORKDIR /opt/nginx-${NGINX_VERSION}
+RUN patch -p1 < ngx_event_openssl.patch
 RUN ./configure --prefix=${INSTALLDIR} \
                 --with-debug \
                 --with-http_ssl_module --with-openssl=/opt/openssl \

--- a/nginx/fulltest-provider/genconfig.py
+++ b/nginx/fulltest-provider/genconfig.py
@@ -103,9 +103,8 @@ def write_nginx_config(f, i, cf, port, _sig, k):
            if k!="*" :  
               f.write("    ssl_ecdh_curve      "+k+";\n")
            f.write("    location / {\n")
-           f.write("            ssi    on;\n")
-           if k!="*" :  
-              f.write("            set    $oqs_alg_name \""+sig+"-"+k+"\";\n")
+           f.write("            ssi    on;\n") 
+           f.write("            set    $oqs_sig_name \""+sig+"\";\n")
            f.write("            root   html;\n")
            f.write("            index  success.html;\n")
            f.write("    }\n\n")

--- a/nginx/fulltest-provider/ngx_event_openssl.patch
+++ b/nginx/fulltest-provider/ngx_event_openssl.patch
@@ -1,0 +1,94 @@
+diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+index c38aa27f1..82debe09b 100644
+--- a/src/event/ngx_event_openssl.c
++++ b/src/event/ngx_event_openssl.c
+@@ -5102,17 +5102,31 @@ ngx_ssl_get_curve(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+ #ifdef SSL_get_negotiated_group
+ 
+     int  nid;
++#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
++    const char  *grpname;
++#endif
+ 
+     nid = SSL_get_negotiated_group(c->ssl->connection);
++#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
++    grpname = SSL_group_to_name(c->ssl->connection, nid);
++#endif
+ 
+     if (nid != NID_undef) {
+ 
++#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
++        if (grpname != NULL) {
++            s->len = ngx_strlen(grpname);
++            s->data = (u_char *) grpname;
++            return NGX_OK;
++        }
++#else
+         if ((nid & TLSEXT_nid_unknown) == 0) {
+             s->len = ngx_strlen(OBJ_nid2sn(nid));
+             s->data = (u_char *) OBJ_nid2sn(nid);
+             return NGX_OK;
+         }
+ 
++#endif
+         s->len = sizeof("0x0000") - 1;
+ 
+         s->data = ngx_pnalloc(pool, s->len);
+@@ -5140,6 +5154,9 @@ ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+     int         *curves, n, i, nid;
+     u_char      *p;
+     size_t       len;
++#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
++    const char  *grpname;
++#endif
+ 
+     n = SSL_get1_curves(c->ssl->connection, NULL);
+ 
+@@ -5156,12 +5173,23 @@ ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+     for (i = 0; i < n; i++) {
+         nid = curves[i];
+ 
++#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
++        grpname = SSL_group_to_name(c->ssl->connection, nid);
++
++        if (grpname == NULL) {
++            len += sizeof("0x0000") - 1;
++
++        } else {
++            len += ngx_strlen(grpname);
++        }
++#else
+         if (nid & TLSEXT_nid_unknown) {
+             len += sizeof("0x0000") - 1;
+ 
+         } else {
+             len += ngx_strlen(OBJ_nid2sn(nid));
+         }
++#endif
+ 
+         len += sizeof(":") - 1;
+     }
+@@ -5176,12 +5204,22 @@ ngx_ssl_get_curves(ngx_connection_t *c, ngx_pool_t *pool, ngx_str_t *s)
+     for (i = 0; i < n; i++) {
+         nid = curves[i];
+ 
++#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
++        grpname = SSL_group_to_name(c->ssl->connection, nid);
++        if (grpname == NULL) {
++            p = ngx_sprintf(p, "0x%04xd", nid & 0xffff);
++
++        } else {
++            p = ngx_sprintf(p, "%s", grpname);
++        }
++#else
+         if (nid & TLSEXT_nid_unknown) {
+             p = ngx_sprintf(p, "0x%04xd", nid & 0xffff);
+ 
+         } else {
+             p = ngx_sprintf(p, "%s", OBJ_nid2sn(nid));
+         }
++#endif
+ 
+         *p++ = ':';
+     }
+

--- a/nginx/fulltest-provider/success.htm
+++ b/nginx/fulltest-provider/success.htm
@@ -6,10 +6,11 @@
 <body>
 <h1 align=center>
 Successfully connected using
-<!--# echo var="oqs_alg_name" default="unknown" -->
-!
+<!--# echo var="oqs_sig_name" default="unknown" -->-<!--# echo var="ssl_curve" default="unknown" -->!
 </h1>
 
 Client-side KEM algorithm(s) indicated:
 <!--# echo var="ssl_curves" default="no" -->
 </body>
+</html>
+


### PR DESCRIPTION
Updates the build for test.openquantumsafe.org:
- Updates oqs-provider to 0.5.1

Fixes a few issues:
- ssl groups for OQS-kems were not correctly resolved to strings. 

Example:
```
/curl -v --cacert cert.pem --curves x25519_kyber512:kyber768 https://test.openquantumsafe.org:6245/
...
Client-side KEM algorithm(s) indicated:
0x2f39:0x023c
```

The update resolves them correctly:
```
/curl -v --cacert cert.pem --curves x25519_kyber512:kyber768 https://test.openquantumsafe.org:6245/
...
Client-side KEM algorithm(s) indicated:
x25519_kyber512:kyber768
```
-> needed to patch nginx to use `SSL_group_to_name` instead `OBJ_nid2sn` when using OpenSSL >= 3.0.

- signature/kem response was not available with the ports that offer the default groups. Example: 
https://test.openquantumsafe.org:6043 returned `Successfully connected using !`. With the update it returns `Successfully connected using rsa3072-x25519!`

-> updated interop.conf to not hardcode the negotiated group in the response html but instead use nginx's `$ssl_curve` variable available from v1.21.5. Also needed to patch nginx to correctly resolve the string when using OpenSSL >= 3.0.

- server html response was malformed (missing `</html>` tag)

The update is already applied to https://test.openquantumsafe.org.
May see if there is interest in nginx upstream to apply the patch there.