### PR TITLE
Updates docker file to create test server package

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -21,7 +21,7 @@ ARG DEFAULT_GROUPS=x25519:x448:kyber512:p256_kyber512:kyber768:p384_kyber768:kyb
 ARG NGINX_VERSION=1.25.2
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
-ARG MAKE_DEFINES="-j"
+ARG MAKE_DEFINES="-j 18"
 
 
 FROM alpine:3.13 as intermediate
@@ -126,5 +126,7 @@ STOPSIGNAL SIGTERM
 # Enable a normal user to create new server keys off set CA
 RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs ${INSTALLDIR}
 USER oqs
+# From nginx 1.25.2: "nginx does not try to load OpenSSL configuration if the --with-openssl option was used to built OpenSSL and the OPENSSL_CONF environment variable is not set".
+# We therefore have to set the OPENSSL_CONF environment variable.
 ENV OPENSSL_CONF ${OSSLDIR}/ssl/openssl.cnf
 CMD ["nginx", "-c", "nginx-conf/nginx.conf", "-g", "daemon off;"]

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -18,10 +18,10 @@ ARG SIG_ALG="dilithium3"
 ARG DEFAULT_GROUPS=x25519:x448:kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024
 
 # define the nginx version to include
-ARG NGINX_VERSION=1.23.3
+ARG NGINX_VERSION=1.25.2
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
-ARG MAKE_DEFINES="-j 18"
+ARG MAKE_DEFINES="-j"
 
 
 FROM alpine:3.13 as intermediate
@@ -126,6 +126,5 @@ STOPSIGNAL SIGTERM
 # Enable a normal user to create new server keys off set CA
 RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs ${INSTALLDIR}
 USER oqs
-
+ENV OPENSSL_CONF ${OSSLDIR}/ssl/openssl.cnf
 CMD ["nginx", "-c", "nginx-conf/nginx.conf", "-g", "daemon off;"]
-

--- a/nginx/fulltest-provider/Dockerfile
+++ b/nginx/fulltest-provider/Dockerfile
@@ -3,11 +3,11 @@
 # First: global build arguments:
 
 # liboqs build type variant; maximum portability of image:
-ARG LIBOQS_VERSION=0.8.0
+ARG LIBOQS_VERSION=0.9.0
 
 ARG OPENSSL_VERSION=master
 
-ARG OQS_PROVIDER_VERSION=0.5.1
+ARG OQS_PROVIDER_VERSION=main
 
 ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
 
@@ -26,7 +26,7 @@ ARG SIG_ALG="dilithium3"
 ARG DEFAULT_GROUPS=x25519:x448:prime256v1:secp384r1:secp521r1:kyber512:p256_kyber512:kyber768:p384_kyber768:kyber1024:p521_kyber1024
 
 # define the nginx version to include
-ARG NGINX_VERSION=1.25.1
+ARG NGINX_VERSION=1.25.2
 
 # Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
 ARG MAKE_DEFINES="-j"
@@ -97,7 +97,7 @@ COPY genconfig.py ${CONFIGDIR}
 COPY common.py ${CONFIGDIR}
 COPY ext-csr.conf ${CONFIGDIR}
 COPY index-template ${CONFIGDIR}
-COPY chromium-template ${CONFIGDIR}
+#COPY chromium-template ${CONFIGDIR}
 COPY success.htm ${CONFIGDIR}
 COPY OsslAlgParser.scala ${CONFIGDIR}
 
@@ -108,8 +108,8 @@ RUN python3 genconfig.py
 
 RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" index-base.html
 RUN sed -i "s/OQSPROVIDER_RELEASE/${OQS_PROVIDER_VERSION}/g" index-base.html
-RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" chromium-base.html
-RUN sed -i "s/OQSPROVIDER_RELEASE/${OQS_PROVIDER_VERSION}/g" chromium-base.html
+#RUN sed -i "s/LIBOQS_RELEASE/${LIBOQS_VERSION}/g" chromium-base.html
+#RUN sed -i "s/OQSPROVIDER_RELEASE/${OQS_PROVIDER_VERSION}/g" chromium-base.html
 
 RUN rm -rf ${INSTALLDIR}/pki
 RUN rm -rf ${INSTALLDIR}/logs/*

--- a/nginx/fulltest-provider/README.md
+++ b/nginx/fulltest-provider/README.md
@@ -34,6 +34,8 @@ Note that, the oqs-nginx-{LIBOQS_VERSION}.tgz package contains all required conf
 
 Execute `OPENSSL_CONF=/opt/openssl/.openssl/ssl/openssl.cnf /opt/nginx/sbin/nginx -c /opt/nginx/interop.conf` to start the test server.
 
+*Note*: From nginx version 1.25.2, nginx does not try to load OpenSSL configuration if the --with-openssl option was used to built OpenSSL. We therefore have to set the `OPENSSL_CONF` environment variable when activating nginx.
+
 *Note*: As the server many of ports, the server may need to be configured to permit this, e.g., using `ulimit -S -n 4096`.
 
 #### Test run

--- a/nginx/fulltest-provider/README.md
+++ b/nginx/fulltest-provider/README.md
@@ -32,6 +32,10 @@ Note that, the oqs-nginx-{LIBOQS_VERSION}.tgz package contains all required conf
 
 #### Activation
 
-Execute `/opt/nginx/sbin/nginx -c /opt/nginx/interop.conf` to start the test server.
+Execute `OPENSSL_CONF=/opt/openssl/.openssl/ssl/openssl.cnf /opt/nginx/sbin/nginx -c /opt/nginx/interop.conf` to start the test server.
 
 *Note*: As the server many of ports, the server may need to be configured to permit this, e.g., using `ulimit -S -n 4096`.
+
+#### Test run
+
+The `testrun.sh` script runs test connections against all ports configured by the server. To run the script, execute `testrun.sh openquantumsafe/curl`.

--- a/nginx/fulltest-provider/build_ubuntu.sh
+++ b/nginx/fulltest-provider/build_ubuntu.sh
@@ -9,4 +9,4 @@
 docker build --no-cache -t oqs-nginx-fulltest-provider .
 
 # Copy tar from image
-docker cp $(docker create oqs-nginx-fulltest-provider:latest):oqs-nginx-0.8.0.tgz .
+docker cp $(docker create oqs-nginx-fulltest-provider:latest):oqs-nginx-0.9.0.tgz .


### PR DESCRIPTION
The update uses..
- liboqs 0.9.0
- latest oqs-provider (main)
- latest nginx 1.25.2

Also updates the nginx docker demo to v1.25.2.
Note that with [nginx 1.25.2](http://nginx.org/en/CHANGES), the location of the openssl config file needs to be passed as an env variable. This is reflected in the Dockerfile of the nginx demo.

The updated package is already deployed at test.openquantumsafe.org.
A test run with `testrun.sh` passes.
I'll update the server again to a tagged oqs-provider release once available.