### PR TITLE
search for ossl-modules path

### DIFF
--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -78,7 +78,7 @@ RUN sed -i "s/default = default_sect/default = default_sect\noqsprovider = oqspr
 
 # build oqs-provider
 WORKDIR /opt/oqs-provider
-RUN rm -rf build && cmake -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=${OPENSSL_PATH} -DCMAKE_PREFIX_PATH=${OPENSSL_PATH} -S . -B build && cmake --build build && cp build/lib/oqsprovider.so ${OPENSSL_PATH}/lib64/ossl-modules/oqsprovider.so
+RUN rm -rf build && cmake -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=${OPENSSL_PATH} -DCMAKE_PREFIX_PATH=${OPENSSL_PATH} -S . -B build && cmake --build build && export MODULESDIR=$(find ${OPENSSL_PATH} -name ossl-modules) && cp build/lib/oqsprovider.so $MODULESDIR/oqsprovider.so
 
 # build httpd
 WORKDIR /opt

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -69,7 +69,7 @@ RUN mkdir -p ${OSSLDIR=}/ssl && cp /opt/openssl/apps/openssl.cnf ${OSSLDIR}/ssl/
 # build oqsprovider
 WORKDIR /opt/oqs-provider
 
-RUN ln -s /opt/nginx/include/oqs ${OSSLDIR}/include && rm -rf build && cmake -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=${OSSLDIR} -DCMAKE_PREFIX_PATH=$INSTALLDIR -S . -B build && cmake --build build && mkdir -p ${OSSLDIR}/lib64/ossl-modules && cp build/lib/oqsprovider.so ${OSSLDIR}/lib64/ossl-modules && rm -rf ${INSTALLDIR}/lib64
+RUN ln -s /opt/nginx/include/oqs ${OSSLDIR}/include && rm -rf build && cmake -DCMAKE_BUILD_TYPE=Debug -DOPENSSL_ROOT_DIR=${OSSLDIR} -DCMAKE_PREFIX_PATH=$INSTALLDIR -S . -B build && cmake --build build && export MODULESDIR=$(find ${OSSLDIR} -name ossl-modules) && cp build/lib/oqsprovider.so $MODULESDIR && mkdir -p ${OSSLDIR}/lib64 && ln -s ${OSSLDIR}/lib/ossl-modules ${OSSLDIR}/lib64 && rm -rf ${INSTALLDIR}/lib64
 
 WORKDIR ${INSTALLDIR}
 


### PR DESCRIPTION
OpenSSL installs providers in a hardware-dependent path, either "INSTALLDIR/lib/ossl-modules" or "INSTALLDIR/lib64/ossl-modules". This PR enables Dockerfiles to correctly build and deploy on platforms with either option.

Fixes #247
Fixes #248 