### PR TITLE
Update USAGE.md

### DIFF
--- a/chromium/USAGE.md
+++ b/chromium/USAGE.md
@@ -17,4 +17,27 @@ Please note that not all algorithm combinations are expected to work. Most notab
 
 Please create a [discussion item](https://github.com/open-quantum-safe/boringssl/discussions/landing) if you feel some algorithm combination that does not work should do.
 
+## Issues and Workarounds
 
+### Ubuntu/Deb
+
+`ERROR:nsNSSCertificateDB.cpp(95)] PK11_ImportCert failed with error -8168`
+
+There are a few things to try should you recieve this error whilst importing your proxy CA certificate:
+
+1. Manually install CA cert into nssdb.
+```sh
+# Change permissions to avoid error "read only database"
+# chmod -R 766 /home/username/.pki/
+# manually invoke certutl
+# certutil -d sql:$HOME/.pki/nssdb -A -t "CT,c,c" -n "CertName" -i /usr/share/ca-certificates/your_ca.crt
+```
+If running this in ansible you may need to replace $HOME with a path to the target users home directory instead of $HOME.
+
+2. Symlink Linux trust store over libnss file (last resort)
+```
+#backup store
+mv /usr/lib/x86_64-linux-gnu/libnssckbi.so /usr/lib/x86_64-linux-gnu/libnssckbi.so.bak
+#create symlink
+ln -s -f /usr/lib/x86_64-linux-gnu/pkcs11/p11-kit-trust.so /usr/lib/x86_64-linux-gnu/libnssckbi.so
+```


### PR DESCRIPTION
issues and workarounds readme section added with specific reference to: `ERROR:nsNSSCertificateDB.cpp(95)] PK11_ImportCert failed with error -8168` and the solutions to that.