### PR TITLE
Dockerfile Upgrades and Optimizations

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -7,7 +7,7 @@ ARG LIBOQS_TAG=main
 ARG OQSPROVIDER_TAG=main
 
 # define the Curl version to be baked in
-ARG CURL_VERSION=7.81.0
+ARG CURL_VERSION=8.10.1
 
 # Default location where all binaries wind up:
 ARG INSTALLDIR=/opt/oqssa
@@ -40,10 +40,10 @@ LABEL version="4"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apk update && apk upgrade
+RUN apk update
 
 # Get all software packages required for builing all components:
-RUN apk add build-base linux-headers \
+RUN apk add --no-cache build-base linux-headers \
             libtool automake autoconf cmake ninja \
             make \
             openssl openssl-dev \
@@ -57,8 +57,8 @@ RUN git clone --depth 1 --branch ${LIBOQS_TAG} https://github.com/open-quantum-s
     wget https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz && tar -zxvf curl-${CURL_VERSION}.tar.gz;
 
 # build liboqs
-WORKDIR /opt/liboqs
-RUN mkdir build && cd build && cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
+WORKDIR /opt/liboqs/build
+RUN cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
 
 # build OpenSSL3
 WORKDIR /opt/openssl

--- a/curl/Dockerfile-QUIC
+++ b/curl/Dockerfile-QUIC
@@ -1,22 +1,53 @@
-FROM ubuntu:latest AS build
+FROM ubuntu:24.04 AS build
 
 ARG CURL_VERSION=8.10.1
 ARG QUICHE_VERSION=0.22.0
 
-RUN apt update && apt install cmake gcc ninja-build libunwind-dev pkg-config build-essential cargo git wget -y && cd /root && \
-# Clone BoringSSL&liboqs
-  git clone --branch master https://github.com/open-quantum-safe/boringssl.git bssl && git clone --branch main --single-branch --depth 1 https://github.com/open-quantum-safe/liboqs.git && \
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y cmake gcc ninja-build libunwind-dev pkg-config build-essential cargo git wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set working directory to /root
+WORKDIR /root
+
+# Clone BoringSSL and liboqs
+RUN git clone --branch master https://github.com/open-quantum-safe/boringssl.git bssl && \
+    git clone --branch main --single-branch --depth 1 https://github.com/open-quantum-safe/liboqs.git
+
 # Build liboqs
-  cd liboqs && mkdir build && cd build && cmake -G"Ninja" -DCMAKE_INSTALL_PREFIX=../../bssl/oqs -DOQS_USE_OPENSSL=OFF .. && ninja && ninja install && \
+WORKDIR /root/liboqs/build
+RUN cmake -G"Ninja" -DCMAKE_INSTALL_PREFIX=../../bssl/oqs -DOQS_USE_OPENSSL=OFF .. && \
+    ninja && ninja install
+
 # Build BoringSSL
-  cd /root/bssl && mkdir build && cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 .. && ninja && ninja install && cp -rp ../install/include /usr/local/include/bssl && cp -rp ../install/lib /usr/local/lib/bssl && \
-# Build quiche
-  cd /root && git clone --recursive -b ${QUICHE_VERSION} https://github.com/cloudflare/quiche && cd quiche/quiche/deps && rm -R boringssl && ln -s /root/bssl boringssl && cd /root/quiche && cargo build --package quiche --release --features ffi,pkg-config-meta,qlog && cp -p target/release/libquiche.so /usr/local/lib/bssl/libquiche.so.0 && \
-# Build curl
-  cd /root && wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz && tar -zxf curl-${CURL_VERSION}.tar.gz && rm -R curl-${CURL_VERSION}.tar.gz && mv curl-${CURL_VERSION} curl && cd curl && LIBS=-lpthread ./configure LDFLAGS="-Wl,-rpath,/usr/local/lib/bssl" --with-openssl=/root/bssl/install --with-quiche=/root/quiche/target/release --without-libpsl --prefix="/usr/local/curl" && make && make install
+WORKDIR /root/bssl/build
+RUN cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 .. && \
+    ninja && ninja install && \
+    cp -rp ../install/include /usr/local/include/bssl && \
+    cp -rp ../install/lib /usr/local/lib/bssl
 
+# Clone and build quiche
+WORKDIR /root
+RUN git clone --recursive -b ${QUICHE_VERSION} https://github.com/cloudflare/quiche && \
+    rm -R quiche/quiche/deps/boringssl && \
+    ln -s /root/bssl quiche/quiche/deps/boringssl && \
+    cd quiche && \
+    cargo build --package quiche --release --features ffi,pkg-config-meta,qlog && \
+    cp -p target/release/libquiche.so /usr/local/lib/bssl/libquiche.so.0
 
-FROM ubuntu:latest
+# Clone and build curl
+RUN wget https://curl.se/download/curl-${CURL_VERSION}.tar.gz && \
+    tar -zxf curl-${CURL_VERSION}.tar.gz && rm -R curl-${CURL_VERSION}.tar.gz && \
+    mv curl-${CURL_VERSION} curl
+
+WORKDIR /root/curl
+RUN LIBS=-lpthread ./configure LDFLAGS="-Wl,-rpath,/usr/local/lib/bssl" \
+    --with-openssl=/root/bssl/install --with-quiche=/root/quiche/target/release --without-libpsl \
+    --prefix="/usr/local/curl" && \
+    make && make install
+
+# Stage 2: Final image
+FROM ubuntu:24.04
 
 COPY --from=build /usr/local/include/bssl /usr/local/include/bssl
 COPY --from=build /usr/local/lib/bssl /usr/local/lib/bssl

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -11,7 +11,7 @@ ARG MAKE_DEFINES="-j 8"
 
 ARG SIG_ALG="dilithium3"
 
-FROM alpine:3.13 as buildopenssl
+FROM alpine:3.20.3 AS buildopenssl
 # Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
@@ -22,23 +22,23 @@ ARG SIG_ALG
 LABEL version="1"
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apk update && apk upgrade
 
 # Get all software packages required for builing openssl
-RUN apk add build-base linux-headers \
+RUN apk add --no-cache build-base linux-headers \
             libtool automake autoconf \
             make \
             git wget
 
 # get current openssl sources
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch master https://github.com/openssl/openssl.git
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
 
 # build OpenSSL3
 WORKDIR /optbuild/openssl
 RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" ./config shared --prefix=${INSTALLDIR_OPENSSL} && \
     make ${MAKE_DEFINES} && make install && if [ -d ${INSTALLDIR_OPENSSL}/lib64 ]; then ln -s ${INSTALLDIR_OPENSSL}/lib64 ${INSTALLDIR_OPENSSL}/lib; fi && if [ -d ${INSTALLDIR_OPENSSL}/lib ]; then ln -s ${INSTALLDIR_OPENSSL}/lib ${INSTALLDIR_OPENSSL}/lib64; fi 
 
-FROM alpine:3.13 as buildliboqs
+FROM alpine:3.20.3 AS buildliboqs
 # Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
@@ -50,7 +50,7 @@ LABEL version="1"
 ENV DEBIAN_FRONTEND noninteractive
 
 # Get all software packages required for builing liboqs:
-RUN apk add build-base linux-headers \
+RUN apk add --no-cache build-base linux-headers \
             libtool automake autoconf cmake ninja \
             make \
             git wget
@@ -58,12 +58,13 @@ RUN apk add build-base linux-headers \
 # Get OpenSSL image (from cache)
 COPY --from=buildopenssl ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/liboqs
 
-WORKDIR /optbuild/liboqs
-RUN mkdir build && cd build && cmake -G"Ninja" .. -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && ninja install
+WORKDIR /optbuild/liboqs/build
+RUN cmake -G"Ninja" .. -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && ninja install
 
-FROM alpine:3.13 as buildoqsprovider
+FROM alpine:3.20.3 AS buildoqsprovider
 # Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
@@ -75,11 +76,12 @@ LABEL version="1"
 ENV DEBIAN_FRONTEND noninteractive
 
 # Get all software packages required for builing oqsprovider
-RUN apk add build-base linux-headers \
+RUN apk add --no-cache build-base linux-headers \
             libtool cmake ninja \
             git wget
 
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch main https://github.com/open-quantum-safe/oqs-provider.git
 
 # Get openssl32 and liboqs
 COPY --from=buildopenssl ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
@@ -98,7 +100,7 @@ RUN set -x; \
     openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:3.13 as dev
+FROM alpine:3.20.3 AS dev
 # Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG SIG_ALG

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -1,4 +1,4 @@
-# Multi-stage build: First the full builder image:
+# Multi-stage build: First the full builder image
 
 # define the liboqs tag to be used
 ARG LIBOQS_TAG=main
@@ -21,7 +21,7 @@ ARG MAKE_DEFINES="-j 4"
 # Default KEM algorithms to be utilized
 ARG KEM_ALGLIST="kyber768:p384_kyber768"
 
-FROM debian:bullseye as intermediate
+FROM debian:bullseye AS intermediate
 # Take in all global args
 ARG LIBOQS_TAG
 ARG OQSPROVIDER_TAG
@@ -35,10 +35,8 @@ LABEL version="2"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update && apt -y upgrade
-
 # Get all software packages required for builing all components:
-RUN apt install -y  \
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
             libtool automake autoconf cmake ninja-build \
             make \
             openssl libssl-dev pkg-config libcap-ng-dev \
@@ -54,8 +52,8 @@ RUN git clone --depth 1 --branch ${LIBOQS_TAG} https://github.com/open-quantum-s
     git clone https://github.com/OpenVPN/openvpn.git
 
 # build liboqs
-WORKDIR /opt/liboqs
-RUN mkdir build && cd build && cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
+WORKDIR /opt/liboqs/build
+RUN cmake -G"Ninja" .. ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR} && ninja install
 
 # build OpenSSL3
 WORKDIR /opt/openssl
@@ -86,7 +84,7 @@ ARG INSTALLDIR
 ARG OPENVPNDIR
 
 # install basics to run executable and enable network control
-RUN apt update && apt upgrade -y && apt install -y liblzo2-2 libnl-3-200 libnl-genl-3-200 procps net-tools iputils-ping && mkdir -p ${OPENVPNDIR}
+RUN apt-get update && apt-get install -y --no-install-recommends liblzo2-2 libnl-3-200 libnl-genl-3-200 procps net-tools iputils-ping && rm -rf /var/lib/apt/lists/* && mkdir -p ${OPENVPNDIR}
 
 # Only retain the ${INSTALLDIR} contents in the final image
 COPY --from=intermediate ${INSTALLDIR} ${INSTALLDIR}

--- a/wireshark/Dockerfile
+++ b/wireshark/Dockerfile
@@ -1,56 +1,40 @@
 # Define the wireshark version to be baked in.
-ARG WIRESHARK_VERSION=3.4.9
+ARG WIRESHARK_VERSION=4.4.1
 
 # Define the SSL naming convention: One of "wolfssl" and "oqs"
 ARG QSC_SSL_FLAVOR="oqs"
 
-FROM ubuntu as intermediate
+FROM ubuntu:24.04 AS intermediate
 ENV DEBIAN_FRONTEND noninteractive
 
 ARG WIRESHARK_VERSION
 ARG QSC_SSL_FLAVOR
 
-RUN apt update && apt upgrade -y
-
 # Get all software packages required for building wireshark:
-RUN apt install -y gcc g++ \
-            libtool \
-            automake \
-            autoconf \
-            cmake \
-            ninja-build \
-            git \
-            curl \
-            perl \
-            flex \
-            bison \
-            2to3 python2-minimal python2 dh-python python-is-python3 \
-            python3 \
-            libssl-dev \
-            libgcrypt-dev \
-            libpcap-dev \
-            libc-ares-dev \
-            qtbase5-dev qttools5-dev-tools qttools5-dev qtmultimedia5-dev \
-            wget \
-            libssh-dev
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc g++ libtool automake autoconf cmake ninja-build git curl perl flex bison \
+        python2-minimal python3 libssl-dev libgcrypt-dev libpcap-dev libc-ares-dev \
+        qtbase5-dev qttools5-dev-tools qtmultimedia5-dev libssh-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Get the source and unpack it.
+# Download and extract Wireshark source
 WORKDIR /tmp
-RUN curl --output wireshark-${WIRESHARK_VERSION}.tar.xz https://2.na.dl.wireshark.org/src/all-versions/wireshark-${WIRESHARK_VERSION}.tar.xz && tar xmvf wireshark-${WIRESHARK_VERSION}.tar.xz
+RUN curl -sLO "https://2.na.dl.wireshark.org/src/all-versions/wireshark-${WIRESHARK_VERSION}.tar.xz" && \
+    tar -xf "wireshark-${WIRESHARK_VERSION}.tar.xz"
 
-WORKDIR /tmp/wireshark-${WIRESHARK_VERSION} 
+WORKDIR /tmp/wireshark-${WIRESHARK_VERSION}
 
 COPY wolfssl-qsc.h wolfssl-qsc.h
 
 # Decide on QSC naming/ID mapping
-RUN if [ "x$QSC_SSL_FLAVOR" = "xoqs" ] ; then \
-   wget https://raw.githubusercontent.com/open-quantum-safe/openssl/OQS-OpenSSL_1_1_1-stable/qsc.h; \
-elif [ "x$QSC_SSL_FLAVOR" = "xwolfssl" ]; then \
-   mv wolfssl-qsc.h qsc.h; \
-else \
-   echo "Unknown naming convention in QSC_SSL_FLAVOR ($QSC_SSL_FLAVOR). Exiting."; \
-   exit 1; \
-fi
+RUN if [ "x$QSC_SSL_FLAVOR" = "xoqs" ]; then \
+       curl -sLO https://raw.githubusercontent.com/open-quantum-safe/openssl/OQS-OpenSSL_1_1_1-stable/qsc.h; \
+    elif [ "x$QSC_SSL_FLAVOR" = "xwolfssl" ]; then \
+       mv wolfssl-qsc.h qsc.h; \
+    else \
+       echo "Unknown naming convention in QSC_SSL_FLAVOR ($QSC_SSL_FLAVOR). Exiting."; exit 1; \
+    fi
 
 # Patch QSC-specific ids into wireshark code base
 RUN cp qsc.h epan/dissectors && \
@@ -60,16 +44,22 @@ RUN cp qsc.h epan/dissectors && \
    sed -i "s/    { 260\, \"ffdhe8192\" }\, \/\* RFC 7919 \*\//    { 260\, \"ffdhe8192\" }\, \/\* RFC 7919 \*\/\nQSC_KEMS/g" epan/dissectors/packet-tls-utils.c && \
    sed -i "s/ { 0x080b\, \"rsa_pss_pss_sha512\" }\,/ { 0x080b\, \"rsa_pss_pss_sha512\" }\,\nQSC_SIG_CPS/g" epan/dissectors/packet-tls-utils.c
 
-# Build wireshark
-RUN mkdir -p build && cd build && cmake -GNinja -DCMAKE_INSTALL_PREFIX=/opt/wireshark .. && ninja && ninja install
+# Build Wireshark
+WORKDIR /tmp/wireshark-${WIRESHARK_VERSION}/build
+RUN cmake -GNinja -DCMAKE_INSTALL_PREFIX=/opt/wireshark .. && \
+    ninja && ninja install
 
-FROM ubuntu
-ENV DEBIAN_FRONTEND noninteractive
+# Final stage - reduce image size by only copying essential files
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt upgrade -y && apt install -y qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libc-ares2 libqt5multimedia5 pcaputils libssh-dev
+# Install runtime dependencies
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        qt5-qmake qtchooser libqt5multimedia5 libc-ares2 libpcap-dev libssh-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Only retain the ${INSTALLDIR} contents in the final image
+# Copy compiled Wireshark from intermediate stage
 COPY --from=intermediate /opt/wireshark /opt/wireshark
 
-
-CMD /opt/wireshark/bin/wireshark
+CMD ["/opt/wireshark/bin/wireshark"]


### PR DESCRIPTION
This pull request introduces multiple updates to improve build efficiency, reduce image size, and increase the stability of the Dockerfiles. Key changes include:

- **Base Image Upgrades**:
  - Upgraded to `Ubuntu 24.04` and `Alpine 3.20.3`.
  - Updated Wireshark to version `4.4.1`.

- **Optimizations in Dockerfile Build Stages**:
  - Replaced `apt` with `apt-get` and added `--no-install-recommends` to minimize unnecessary packages in Ubuntu-based images.
  - Simplified `apk` commands with `--no-cache` and removed `apk upgrade` in Alpine-based images to reduce image size and improve stability.
  - Standardized download commands to use `curl` over `wget` for consistency.
  
- **Efficiency Improvements**:
  - Streamlined directory handling using `WORKDIR` instead of multiple `RUN mkdir` commands.
  - Cleaned up `apt` and `apk` cache to reduce final image sizes.