### PR TITLE
Address docker build warnings

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -31,7 +31,7 @@ ARG DEFAULT_GROUPS="x25519:x448:kyber512:p256_kyber512:kyber768:p384_kyber768:ky
 ARG MAKE_DEFINES="-j 4"
 
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 # Take in all global args
 ARG OPENSSL_TAG
 ARG LIBOQS_TAG
@@ -123,7 +123,7 @@ COPY serverstart.sh ${INSTALLDIR}/bin
 CMD ["serverstart.sh"]
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:${ALPINE_VERSION} as dev
+FROM alpine:${ALPINE_VERSION} AS dev
 # Take in all global args
 ARG INSTALLDIR
 ARG SIG_ALG

--- a/h2load/Dockerfile
+++ b/h2load/Dockerfile
@@ -3,7 +3,7 @@
 # define the alpine image version to use
 ARG ALPINE_VERSION=3.20
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -75,7 +75,7 @@ RUN mkdir /opt/lib && cd /opt/lib && \
         cp /usr/lib/libgcc_s.so.* .
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:${ALPINE_VERSION} as dev
+FROM alpine:${ALPINE_VERSION} AS dev
 ENV DEBIAN_FRONTEND=noninteractive
 
 # copy executable

--- a/httpd/Dockerfile
+++ b/httpd/Dockerfile
@@ -44,7 +44,7 @@ ARG APR_MIRROR="https://dlcdn.apache.org"
 ARG MAKE_DEFINES="-j 4"
 
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 # Take in global args
 ARG OPENSSL_TAG
 ARG LIBOQS_TAG

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -36,7 +36,7 @@ ARG NGINX_VERSION=1.27.2
 ARG MAKE_DEFINES="-j 18"
 
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 # Take in global args
 ARG OPENSSL_TAG
 ARG LIBOQS_TAG

--- a/nginx/fulltest/Dockerfile
+++ b/nginx/fulltest/Dockerfile
@@ -34,7 +34,7 @@ ARG MAKE_DEFINES="-j"
 # Root CA directory
 ARG CAROOTDIR="/rootca"
 
-FROM ubuntu:focal-20230412 as intermediate
+FROM ubuntu:focal-20230412 AS intermediate
 # Take in global args
 ARG BASEDIR
 ARG CONFIGDIR

--- a/ngtcp2/Dockerfile-client
+++ b/ngtcp2/Dockerfile-client
@@ -3,7 +3,7 @@
 # define the alpine image version to use
 ARG ALPINE_VERSION=3.20
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -83,7 +83,7 @@ RUN mkdir /opt/lib && cd /opt/lib && \
         cp /usr/lib/libgcc_s.so.* .
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:${ALPINE_VERSION} as dev
+FROM alpine:${ALPINE_VERSION} AS dev
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apk update && apk upgrade

--- a/ngtcp2/Dockerfile-server
+++ b/ngtcp2/Dockerfile-server
@@ -3,7 +3,7 @@
 # define the alpine image version to use
 ARG ALPINE_VERSION=3.20
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -87,7 +87,7 @@ RUN mkdir /opt/lib && cd /opt/lib && \
         cp /usr/lib/libgcc_s.so.* .
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:${ALPINE_VERSION} as dev
+FROM alpine:${ALPINE_VERSION} AS dev
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apk update && apk upgrade && apk add mailcap && echo "This is my index page">index.html

--- a/openssh/Dockerfile
+++ b/openssh/Dockerfile
@@ -28,7 +28,7 @@ ARG MAKE_INSTALL="install-nokeys"
 ARG OQS_USER="oqs"
 ARG OQS_PASSWORD="Pa55W0rd"
 
-FROM alpine:${ALPINE_VERSION} as intermediate
+FROM alpine:${ALPINE_VERSION} AS intermediate
 # Take in all global args
 ARG INSTALL_DIR
 ARG LIBOQS_TAG
@@ -85,7 +85,7 @@ STOPSIGNAL SIGTERM
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
 
-FROM alpine:${ALPINE_VERSION} as dev
+FROM alpine:${ALPINE_VERSION} AS dev
 # Take in all global args
 ARG DEFAULT_INSTALL_DIR
 ARG INSTALL_DIR

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -23,7 +23,7 @@ ARG MAKE_DEFINES="-j 8"
 
 ARG SIG_ALG="dilithium3"
 
-FROM alpine:${ALPINE_VERSION} as buildopenssl
+FROM alpine:${ALPINE_VERSION} AS buildopenssl
 # Take in all global args
 ARG OPENSSL_TAG
 ARG INSTALLDIR_OPENSSL
@@ -54,7 +54,7 @@ RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" ./config shared --prefi
     if [ -d ${INSTALLDIR_OPENSSL}/lib64 ]; then ln -s ${INSTALLDIR_OPENSSL}/lib64 ${INSTALLDIR_OPENSSL}/lib; fi && \
     if [ -d ${INSTALLDIR_OPENSSL}/lib ]; then ln -s ${INSTALLDIR_OPENSSL}/lib ${INSTALLDIR_OPENSSL}/lib64; fi
 
-FROM alpine:${ALPINE_VERSION} as buildliboqs
+FROM alpine:${ALPINE_VERSION} AS buildliboqs
 # Take in all global args
 ARG LIBOQS_TAG
 ARG INSTALLDIR_OPENSSL
@@ -83,7 +83,7 @@ RUN mkdir build && \
     cmake -G"Ninja" .. -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && \
     ninja install
 
-FROM alpine:${ALPINE_VERSION} as buildoqsprovider
+FROM alpine:${ALPINE_VERSION} AS buildoqsprovider
 # Take in all global args
 ARG OQSPROVIDER_TAG
 ARG INSTALLDIR_OPENSSL
@@ -126,7 +126,7 @@ RUN set -x; \
     openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM alpine:${ALPINE_VERSION} as dev
+FROM alpine:${ALPINE_VERSION} AS dev
 # Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG SIG_ALG

--- a/openssl3/Dockerfile-interop
+++ b/openssl3/Dockerfile-interop
@@ -20,7 +20,7 @@ ARG MAKE_DEFINES="-j 8"
 
 ARG SIG_ALG="dilithium3"
 
-FROM ubuntu as buildopenssl
+FROM ubuntu AS buildopenssl
 # Take in all global args
 ARG OPENSSL_TAG
 ARG INSTALLDIR_OPENSSL
@@ -48,7 +48,7 @@ RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" ./config shared --prefi
     if [ -d ${INSTALLDIR_OPENSSL}/lib64 ]; then ln -s ${INSTALLDIR_OPENSSL}/lib64 ${INSTALLDIR_OPENSSL}/lib; fi && \
     if [ -d ${INSTALLDIR_OPENSSL}/lib ]; then ln -s ${INSTALLDIR_OPENSSL}/lib ${INSTALLDIR_OPENSSL}/lib64; fi
 
-FROM ubuntu as buildliboqs
+FROM ubuntu AS buildliboqs
 # Take in all global args
 ARG LIBOQS_TAG
 ARG INSTALLDIR_OPENSSL
@@ -76,7 +76,7 @@ RUN mkdir build && \
     cmake -G"Ninja" .. -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && \
     ninja install
 
-FROM ubuntu as buildoqsprovider
+FROM ubuntu AS buildoqsprovider
 # Take in all global args
 ARG OQSPROVIDER_TAG
 ARG INSTALLDIR_OPENSSL
@@ -123,7 +123,7 @@ RUN set -x; \
     openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365
 
 ## second stage: Only create minimal image without build tooling and intermediate build results generated above:
-FROM ubuntu as dev
+FROM ubuntu AS dev
 # Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG SIG_ALG

--- a/openvpn/Dockerfile
+++ b/openvpn/Dockerfile
@@ -26,7 +26,7 @@ ARG MAKE_DEFINES="-j 4"
 # Default KEM algorithms to be utilized
 ARG KEM_ALGLIST="kyber768:p384_kyber768"
 
-FROM debian:bullseye as intermediate
+FROM debian:bullseye AS intermediate
 # Take in all global args
 ARG OPENSSL_TAG
 ARG LIBOQS_TAG


### PR DESCRIPTION
When building, docker throws the following warning:

```
The 'as' keyword should match the case of the 'from' keyword:
FromAsCasing: 'as' and 'FROM' keywords' casing do not match More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
```

This came up as warning annotations in GitHub Actions in #321 