### PR TITLE
Follow-up to PR #316: Fix Wireshark Dockerfile and update documentations

### DIFF
--- a/wireshark/Dockerfile
+++ b/wireshark/Dockerfile
@@ -27,7 +27,7 @@ ARG INSTALLDIR
 # Install essential build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential libtool automake autoconf cmake ninja-build \
-    openssl libssl-dev git wget ca-certificates  \
+    git wget ca-certificates  \
     python3 python3-pip python3-venv && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -53,7 +53,6 @@ RUN cmake -G Ninja /opt/src/liboqs \
     -D CMAKE_INSTALL_PREFIX=${INSTALLDIR}/liboqs \
     -D BUILD_SHARED_LIBS=ON \
     -D OQS_USE_OPENSSL=OFF \
-    -D OQS_MINIMAL_BUILD="KEM_kyber_512;KEM_kyber_768;KEM_kyber_1024" \
     -D CMAKE_INSTALL_RPATH="${INSTALLDIR}/liboqs/lib" && \
     ninja -j$(nproc) && ninja install
 

--- a/wireshark/README.md
+++ b/wireshark/README.md
@@ -32,11 +32,7 @@ image allows Wireshark to analyze network traffic encrypted with post-quantum cr
         export DISPLAY=<your_host_ip>:0
         ```
 
-**Notes**:
-
-- **macOS** support has not been tested yet. We welcome your feedback and suggestions. Please reach us through
-  the [oqs-demos issue section](https://github.com/open-quantum-safe/oqs-demos/issues).
-- Replace `<your_host_ip>` with your system's IP address. Use `:0` as the default display port unless configured
+**Note**: Replace `<your_host_ip>` with your system's IP address. Use `:0` as the default display port unless configured
   otherwise.
 
 ## Building Instructions

--- a/wireshark/USAGE.md
+++ b/wireshark/USAGE.md
@@ -4,7 +4,7 @@ support through the [Open Quantum Safe (OQS) provider](https://github.com/open-q
 
 ## Running Wireshark
 
-You can run the Wireshark Docker container on Linux or Windows using the following command:
+You can run the Wireshark Docker container on Linux, Windows, or macOS using the following command:
 
 ```
 docker run --rm -it --net=host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix oqs-wireshark
@@ -12,9 +12,6 @@ docker run --rm -it --net=host -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-u
 
 Once Wireshark is running, you can [use it as you normally would](https://www.wireshark.org/docs/),
 such as selecting a network interface to capture and analyze traffic.
-
-**Note:** **macOS** support has not been tested yet. We welcome your feedback and suggestions. Please reach us through
-the [oqs-demos issue section](https://github.com/open-quantum-safe/oqs-demos/issues).
 
 ## Testing quantum-safe Protocols
 
@@ -36,7 +33,7 @@ like `ping` to find the IP).
 Run the following command to test a quantum-safe TLS connection:
 
 ```
-docker run -it openquantumsafe/curl sh -c "curl -k https://test.openquantumsafe.org:6069 --curves kyber1024"
+docker run --rm -it openquantumsafe/curl sh -c "curl -k https://test.openquantumsafe.org:6069 --curves kyber1024"
 ```
 
 **Explanation:**


### PR DESCRIPTION
### Description

- Removed `OQS_MINIMAL_BUILD` flag from the Dockerfile as it was added mistakenly and caused a bug.
- Updated documentation to reflect confirmed macOS support for the Wireshark demo, as @ajbozarth  indicates it is working.
- Added the `--rm` flag to the testing command for better cleanup after container execution.
- Removed `openssl` and `libssl-dev` from the build stage of the Dockerfile as they are not required for the build process. 


Resolves: #324
