### PR TITLE
Add GitHub Actions workflow to lint Dockerfiles

### DIFF
--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -1,0 +1,58 @@
+name: Lint Dockerfiles
+
+# This workflow performs linting for Dockerfiles
+# A successful job indicates the linting process has completed
+# Note: A successful run does not guarantee the Dockerfiles are error-free
+# The job will fail if the target folder is missing or if there is a mismatch in the folder name
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch: 
+
+jobs:
+  lint-dockerfiles:
+    name: ${{ matrix.folder }}
+    runs-on: ubuntu-24.04
+
+    strategy:
+      fail-fast: false 
+      matrix:
+        folder: [curl, h2load, haproxy, httpd, locust, nginx, openssh, openssl3, openvpn, wireshark, ngtcp2]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4     
+
+      - name: Install jq for JSON formatting
+        run: sudo apt-get install -y jq
+        # Install jq to beautify JSON linting reports
+
+      - name: Lint Dockerfiles
+        run: |
+          # Check if the folder exists, otherwise fail the job
+          if [ ! -d "${{ matrix.folder }}" ]; then
+            echo "Folder ${{ matrix.folder }} does not exist"
+            exit 1
+          fi
+
+          # Locate all Dockerfiles in the specified folder
+          files=$(find ${{ matrix.folder }} -type f -name 'Dockerfile*')
+          if [ -z "$files" ]; then
+            echo "No Dockerfiles found in ${{ matrix.folder }}"
+            exit 1
+          fi
+
+          # Lint each Dockerfile and save the output in JSON format
+          for file in $files; do
+            echo "Linting $file"
+            docker run --rm -v "$(pwd):/workspace" -w /workspace hadolint/hadolint hadolint --no-fail --no-color --format json "$file" | jq '.' > "${file}_lint_report.json"
+          done
+
+      - name: Upload Lint Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.folder }}
+          path: ${{ matrix.folder }}/*_lint_report.json 


### PR DESCRIPTION
### Description
This PR introduces a GitHub Actions workflow to lint Dockerfiles using Hadolint via Docker. It employs a matrix strategy to process predefined directories and uploads lint reports as artifacts.

### Details
- **Trigger:** Runs on push to `main`, pull requests, and manual dispatch.
- **Outcome:** Successful execution indicates linting completed but does not ensure Dockerfiles are error-free.
- **Artifacts:** Lint reports are saved in JSON format for review.

### Testing
- Verified workflow functionality in my forked repository under the Actions section.
- Confirmed graceful handling of missing directories or Dockerfiles.
- Validated accurate linting and artifact uploads.

Feedback is appreciated.
