### PR TITLE
Address issues with the push manifest CI workflow

### DIFF
--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -138,20 +138,26 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/curl:${{ inputs.release_tag || 'latest' }}-${{ matrix.arch }}
             openquantumsafe/curl:${{ inputs.release_tag || 'latest' }}-${{ matrix.arch }}
 
+  push-optimized:
+    if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
+    needs: build
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: curl
+      release_tag: optimized
+
+  push-dev:
+    if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
+    needs: build
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: curl-dev
+      release_tag: latest
+
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: curl
-          release_tag: optimized
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: curl-dev
-          release_tag: latest
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: curl
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: curl
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/h2load.yml
+++ b/.github/workflows/h2load.yml
@@ -100,9 +100,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: h2load
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: h2load
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -103,9 +103,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: haproxy
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: haproxy
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/httpd.yml
+++ b/.github/workflows/httpd.yml
@@ -103,9 +103,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: httpd
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: httpd
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/locust.yml
+++ b/.github/workflows/locust.yml
@@ -127,9 +127,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: locust
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: locust
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -94,9 +94,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: mosquitto
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: mosquitto
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -104,9 +104,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: nginx
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: nginx
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/ngtcp2.yml
+++ b/.github/workflows/ngtcp2.yml
@@ -117,16 +117,18 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/ngtcp2-client:${{ inputs.release_tag || 'latest' }}-${{ matrix.arch }}
             openquantumsafe/ngtcp2-client:${{ inputs.release_tag || 'latest' }}-${{ matrix.arch }}
 
-  push:
+  push-server:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: ngtcp2-server
-          release_tag: ${{ inputs.release_tag || 'latest' }}
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: ngtcp2-client
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: ngtcp2-server
+      release_tag: ${{ inputs.release_tag || 'latest' }}
+
+  push-client:
+    if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
+    needs: build
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: ngtcp2-client
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -90,9 +90,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: openssh
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: openssh
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -91,9 +91,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: openssl3
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: openssl3
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -91,9 +91,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: openvpn
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: openvpn
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/wireshark.yml
+++ b/.github/workflows/wireshark.yml
@@ -84,9 +84,7 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: wireshark
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    with:
+      image_name: wireshark
+      release_tag: ${{ inputs.release_tag || 'latest' }}


### PR DESCRIPTION
Contrary to my prior understanding, local workflows can not be called in the uses of a step, only in the uses of a job.

I have update all the workflows to use the push-manifest.yml workflow at the job level instead of step.