### PR TITLE
Update CI to inherit secrets between workflows

### DIFF
--- a/.github/workflow-templates/template.yml
+++ b/.github/workflow-templates/template.yml
@@ -92,9 +92,8 @@ jobs:
   push:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/manifest.yml
-        with:
-          image_name: <demo_name>
-          release_tag: ${{ inputs.release_tag || 'latest' }}
+    uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
+    with:
+      image_name: <demo_name>
+      release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,72 +29,84 @@ on:
 jobs:
   curl:
     uses: ./.github/workflows/curl.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   h2load:
     uses: ./.github/workflows/h2load.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   haproxy:
     uses: ./.github/workflows/haproxy.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   httpd:
     uses: ./.github/workflows/httpd.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   locust:
     uses: ./.github/workflows/locust.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   mosquitto:
     uses: ./.github/workflows/mosquitto.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   nginx:
     uses: ./.github/workflows/nginx.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   ngtcp2:
     uses: ./.github/workflows/ngtcp2.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   openssh:
     uses: ./.github/workflows/openssh.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   openssl3:
     uses: ./.github/workflows/openssl3.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   openvpn:
     uses: ./.github/workflows/openvpn.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}
 
   wireshark:
     uses: ./.github/workflows/wireshark.yml
+    secrets: inherit
     with:
       build_main: ${{ !contains(inputs.build_main == 'true', 'false') }}
       release_tag: ${{ inputs.release_tag }}

--- a/.github/workflows/curl.yml
+++ b/.github/workflows/curl.yml
@@ -142,6 +142,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: curl
       release_tag: optimized
@@ -150,6 +151,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: curl-dev
       release_tag: latest
@@ -158,6 +160,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: curl
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/h2load.yml
+++ b/.github/workflows/h2load.yml
@@ -101,6 +101,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: h2load
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/haproxy.yml
+++ b/.github/workflows/haproxy.yml
@@ -104,6 +104,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: haproxy
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/httpd.yml
+++ b/.github/workflows/httpd.yml
@@ -104,6 +104,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: httpd
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/locust.yml
+++ b/.github/workflows/locust.yml
@@ -128,6 +128,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: locust
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/mosquitto.yml
+++ b/.github/workflows/mosquitto.yml
@@ -95,6 +95,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: mosquitto
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/nginx.yml
+++ b/.github/workflows/nginx.yml
@@ -105,6 +105,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: nginx
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/ngtcp2.yml
+++ b/.github/workflows/ngtcp2.yml
@@ -121,6 +121,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: ngtcp2-server
       release_tag: ${{ inputs.release_tag || 'latest' }}
@@ -129,6 +130,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: ngtcp2-client
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/openssh.yml
+++ b/.github/workflows/openssh.yml
@@ -91,6 +91,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: openssh
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -92,6 +92,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: openssl3
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/openvpn.yml
+++ b/.github/workflows/openvpn.yml
@@ -92,6 +92,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: openvpn
       release_tag: ${{ inputs.release_tag || 'latest' }}

--- a/.github/workflows/wireshark.yml
+++ b/.github/workflows/wireshark.yml
@@ -85,6 +85,7 @@ jobs:
     if: ${{ github.repository == 'open-quantum-safe/oqs-demos' && github.ref == 'refs/heads/main' && github.event_name != 'pull_request'  && inputs.build_main != 'true' }}
     needs: build
     uses: ./.github/workflows/push-manifest.yml
+    secrets: inherit
     with:
       image_name: wireshark
       release_tag: ${{ inputs.release_tag || 'latest' }}


### PR DESCRIPTION
By default called workflows don't have access to secrets, this causes issues when needing access to our dockerhib secrets for push.

This adds `secrets: inherit` to all local workflow calls.

Fixes #334 