### PR TITLE
Upgrade OpenSSL demo dependencies 

### DIFF
--- a/.github/workflows/openssl3.yml
+++ b/.github/workflows/openssl3.yml
@@ -72,8 +72,8 @@ jobs:
 
       - name: Test openssl3 with provider - one baseline and one hybrid QSC algorithm
         run: |
-          docker run --rm --name oqs-ossl3 oqs-ossl3 sh -c "openssl list -providers; /opt/openssl32/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups kyber768 --CAfile /opt/openssl32/bin/CA.crt" &&
-          docker run --rm --name oqs-ossl3 oqs-ossl3 sh -c "KEM_ALG=p521_frodo1344aes /opt/openssl32/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups p521_frodo1344aes --CAfile /opt/openssl32/bin/CA.crt"
+          docker run --rm --name oqs-ossl3 oqs-ossl3 sh -c "openssl list -providers; /opt/openssl/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups kyber768 --CAfile /opt/openssl/bin/CA.crt" &&
+          docker run --rm --name oqs-ossl3 oqs-ossl3 sh -c "KEM_ALG=p521_frodo1344aes /opt/openssl/bin/serverstart.sh; sleep 2; echo 'GET /' | openssl s_client -connect localhost --groups p521_frodo1344aes --CAfile /opt/openssl/bin/CA.crt"
 
       - name: Push Docker image to registries
         if: env.push == 'true'

--- a/openssl3/Dockerfile
+++ b/openssl3/Dockerfile
@@ -1,112 +1,83 @@
-# Multi-stage build: First the full builder image:
+# Define build arguments for version tags, installation paths, and configurations
+ARG ALPINE_VERSION=3.21
+ARG OPENSSL_TAG=openssl-3.4.0
+ARG LIBOQS_TAG=0.12.0
+ARG OQSPROVIDER_TAG=0.8.0
 
-# define the alpine image version to use
-ARG ALPINE_VERSION=3.20
-
-# define the openssl tag to be used
-ARG OPENSSL_TAG=openssl-3.3.2
-
-# define the liboqs tag to be used
-ARG LIBOQS_TAG=0.11.0
-
-# define the oqsprovider tag to be used
-ARG OQSPROVIDER_TAG=0.7.0
-
-ARG INSTALLDIR_OPENSSL=/opt/openssl32
+ARG INSTALLDIR_OPENSSL=/opt/openssl
 ARG INSTALLDIR_LIBOQS=/opt/liboqs
-
-# liboqs build type variant; maximum portability of image:
-ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
-
-# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
-ARG MAKE_DEFINES="-j 8"
 
 ARG SIG_ALG="dilithium3"
 
+# Stage 1: Build OpenSSL
 FROM alpine:${ALPINE_VERSION} AS buildopenssl
-# Take in all global args
 ARG OPENSSL_TAG
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
-ARG LIBOQS_BUILD_DEFINES
-ARG MAKE_DEFINES
 ARG SIG_ALG
 
-LABEL version="2"
-ENV DEBIAN_FRONTEND noninteractive
+LABEL version="3"
 
-RUN apk update && apk upgrade
+RUN apk --no-cache add build-base linux-headers \
+            libtool automake autoconf make git wget
 
-# Get all software packages required for builing openssl
-RUN apk add build-base linux-headers \
-            libtool automake autoconf \
-            make \
-            git wget
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch ${OPENSSL_TAG} https://github.com/openssl/openssl.git
 
-# get current openssl sources
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch ${OPENSSL_TAG} https://github.com/openssl/openssl.git
-
-# build OpenSSL3
+# Configure, compile, and install OpenSSL
 WORKDIR /optbuild/openssl
-RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" ./config shared --prefix=${INSTALLDIR_OPENSSL} && \
-    make ${MAKE_DEFINES} && \
-    make install && \
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" \
+    ./config shared --prefix=${INSTALLDIR_OPENSSL} && \
+    make -j"$(nproc)" && make install && \
     if [ -d ${INSTALLDIR_OPENSSL}/lib64 ]; then ln -s ${INSTALLDIR_OPENSSL}/lib64 ${INSTALLDIR_OPENSSL}/lib; fi && \
     if [ -d ${INSTALLDIR_OPENSSL}/lib ]; then ln -s ${INSTALLDIR_OPENSSL}/lib ${INSTALLDIR_OPENSSL}/lib64; fi
 
+# Stage 2: Build liboqs
 FROM alpine:${ALPINE_VERSION} AS buildliboqs
-# Take in all global args
 ARG LIBOQS_TAG
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
-ARG LIBOQS_BUILD_DEFINES
-ARG MAKE_DEFINES
 ARG SIG_ALG
 
-LABEL version="2"
-ENV DEBIAN_FRONTEND noninteractive
+LABEL version="3"
 
-# Get all software packages required for builing liboqs:
-RUN apk add build-base linux-headers \
+RUN apk --no-cache add build-base linux-headers \
             libtool automake autoconf cmake ninja \
-            make \
-            git wget
+            make git wget
 
-# Get OpenSSL image (from cache)
+# Copy the OpenSSL installation from the previous stage
 COPY --from=buildopenssl ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch ${LIBOQS_TAG} https://github.com/open-quantum-safe/liboqs
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch ${LIBOQS_TAG} https://github.com/open-quantum-safe/liboqs
 
-WORKDIR /optbuild/liboqs
-RUN mkdir build && \
-    cd build && \
-    cmake -G"Ninja" .. -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && \
+# Configure and compile liboqs using the Ninja build system
+WORKDIR /optbuild/liboqs/build
+RUN cmake -G"Ninja" ..  \
+    -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} \
+    -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && \
     ninja install
 
+# Stage 3: Build oqs-provider
 FROM alpine:${ALPINE_VERSION} AS buildoqsprovider
-# Take in all global args
 ARG OQSPROVIDER_TAG
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
-ARG LIBOQS_BUILD_DEFINES
-ARG MAKE_DEFINES
 ARG SIG_ALG
 
-LABEL version="2"
-ENV DEBIAN_FRONTEND noninteractive
+LABEL version="3"
 
-# Get all software packages required for builing oqsprovider
-RUN apk add build-base linux-headers \
-            libtool cmake ninja \
-            git wget
+RUN apk --no-cache add build-base linux-headers \
+            libtool cmake ninja git wget
 
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch ${OQSPROVIDER_TAG} https://github.com/open-quantum-safe/oqs-provider.git
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch ${OQSPROVIDER_TAG} https://github.com/open-quantum-safe/oqs-provider.git
 
-# Get openssl32 and liboqs
+# Copy previously built OpenSSL and liboqs installations
 COPY --from=buildopenssl ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 COPY --from=buildliboqs ${INSTALLDIR_LIBOQS} ${INSTALLDIR_LIBOQS}
 
-# build & install provider (and activate by default)
+# Build, install, and configure the oqs-provider
 WORKDIR /optbuild/oqs-provider
 RUN liboqs_DIR=${INSTALLDIR_LIBOQS} cmake -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${INSTALLDIR_OPENSSL} -S . -B _build && \
     cmake --build _build && \
@@ -117,47 +88,52 @@ RUN liboqs_DIR=${INSTALLDIR_LIBOQS} cmake -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSS
     sed -i "s/providers = provider_sect/providers = provider_sect\nssl_conf = ssl_sect\n\n\[ssl_sect\]\nsystem_default = system_default_sect\n\n\[system_default_sect\]\nGroups = \$ENV\:\:DEFAULT_GROUPS\n/g" ${INSTALLDIR_OPENSSL}/ssl/openssl.cnf && \
     sed -i "s/HOME\t\t\t= ./HOME           = .\nDEFAULT_GROUPS = kyber768/g" ${INSTALLDIR_OPENSSL}/ssl/openssl.cnf
 
+# Update PATH to include the newly installed OpenSSL binaries
 WORKDIR ${INSTALLDIR_OPENSSL}/bin
-# set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR_OPENSSL}/bin:${PATH}"
 
-# generate CA key and cert
+# Generate a Certificate Authority (CA) key and certificate
 RUN set -x; \
     openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365
 
-## second stage: Only create minimal image without build tooling and intermediate build results generated above:
+# Stage 4: Create Minimal Runtime Image
 FROM alpine:${ALPINE_VERSION} AS dev
-# Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG SIG_ALG
 
-# Only retain the ${INSTALLDIR_OPENSSL} contents in the final image
+# Retain only the OpenSSL installation for the final image
 COPY --from=buildoqsprovider ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 
-# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+# Ensure the PATH uses the newly built OpenSSL binaries
 ENV PATH="${INSTALLDIR_OPENSSL}/bin:${PATH}"
 
-# generate certificates for openssl s_server, which is what we will test curl against
+# Set working directory to the OpenSSL binary directory for certificate generation
 WORKDIR ${INSTALLDIR_OPENSSL}/bin
 
-# generate server CSR using pre-set CA.key and cert
-# and generate server cert
+# Create test directories and generate server certificate signing requests (CSR)
+# and server certificates using the pre-generated CA key and certificate
 RUN set -x && mkdir -p /opt/test; \
-    openssl version && openssl list -providers && openssl req -new -newkey ${SIG_ALG} -keyout /opt/test/server.key -out /opt/test/server.csr -nodes -subj "/CN=localhost" && \
+    openssl version && openssl list -providers && \
+    openssl req -new -newkey ${SIG_ALG} -keyout /opt/test/server.key -out /opt/test/server.csr -nodes -subj "/CN=localhost" && \
     openssl x509 -req -in /opt/test/server.csr -out /opt/test/server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
 
+# Copy the server startup script into the OpenSSL binary directory
 COPY serverstart.sh ${INSTALLDIR_OPENSSL}/bin
 
+# Change working directory to the OpenSSL installation root
 WORKDIR ${INSTALLDIR_OPENSSL}
 
+# Stage 5: Final Image Configuration
 FROM dev
 ARG INSTALLDIR_OPENSSL
 
 WORKDIR /
 
-# Enable a normal user to create new server keys off set CA
-RUN addgroup -g 1000 -S oqs && adduser --uid 1000 -S oqs -G oqs && chown -R oqs.oqs /opt/test && chmod go+r ${INSTALLDIR_OPENSSL}/bin/CA.key 
+# Create a non-root user and group to allow key generation using the preset CA
+RUN addgroup -g 1000 -S oqs && \
+    adduser --uid 1000 -S oqs -G oqs && \
+    chown -R oqs:oqs /opt/test && \
+    chmod go+r ${INSTALLDIR_OPENSSL}/bin/CA.key
 
-#USER oqs
-CMD ["serverstart.sh"]
+CMD ["/opt/openssl/bin/serverstart.sh"]
 STOPSIGNAL SIGTERM

--- a/openssl3/Dockerfile-interop
+++ b/openssl3/Dockerfile-interop
@@ -1,111 +1,108 @@
-# Multi-stage build: First the full builder image:
+# Define build arguments for version tags, installation paths, and configurations
+ARG OPENSSL_TAG=openssl-3.4.0
+ARG LIBOQS_TAG=0.12.0
+ARG OQSPROVIDER_TAG=0.8.0
 
-# define the openssl tag to be used
-ARG OPENSSL_TAG=openssl-3.3.2
-
-# define the liboqs tag to be used
-ARG LIBOQS_TAG=0.11.0
-
-# define the oqsprovider tag to be used
-ARG OQSPROVIDER_TAG=0.7.0
-
-ARG INSTALLDIR_OPENSSL=/opt/openssl32
+ARG INSTALLDIR_OPENSSL=/opt/openssl
 ARG INSTALLDIR_LIBOQS=/opt/liboqs
-
-# liboqs build type variant; maximum portability of image:
-ARG LIBOQS_BUILD_DEFINES="-DOQS_DIST_BUILD=ON"
-
-# Define the degree of parallelism when building the image; leave the number away only if you know what you are doing
-ARG MAKE_DEFINES="-j 8"
 
 ARG SIG_ALG="dilithium3"
 
+# Stage 1: Build OpenSSL
 FROM ubuntu AS buildopenssl
-# Take in all global args
+
+LABEL version="3"
+
+ENV DEBIAN_FRONTEND=noninteractive
 ARG OPENSSL_TAG
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
-ARG LIBOQS_BUILD_DEFINES
-ARG MAKE_DEFINES
 ARG SIG_ALG
 
-LABEL version="2"
-ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential clang libtool make gcc \
+    ninja-build cmake libtool wget git ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt upgrade -y
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch ${OPENSSL_TAG} https://github.com/openssl/openssl.git
 
-# Get all software packages required for builing openssl
-RUN apt install -y build-essential clang libtool make gcc ninja-build cmake libtool wget git
-
-# get current openssl sources
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch ${OPENSSL_TAG} https://github.com/openssl/openssl.git
-
-# build OpenSSL3
+# Configure, compile, and install OpenSSL 3 with shared libraries
 WORKDIR /optbuild/openssl
-RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" ./config shared --prefix=${INSTALLDIR_OPENSSL} && \
-    make ${MAKE_DEFINES} && \
-    make install && \
+RUN LDFLAGS="-Wl,-rpath -Wl,${INSTALLDIR_OPENSSL}/lib64" \
+    ./config shared --prefix=${INSTALLDIR_OPENSSL} && \
+    make -j"$(nproc)" && make install && \
     if [ -d ${INSTALLDIR_OPENSSL}/lib64 ]; then ln -s ${INSTALLDIR_OPENSSL}/lib64 ${INSTALLDIR_OPENSSL}/lib; fi && \
     if [ -d ${INSTALLDIR_OPENSSL}/lib ]; then ln -s ${INSTALLDIR_OPENSSL}/lib ${INSTALLDIR_OPENSSL}/lib64; fi
 
+# Stage 2: Build liboqs
 FROM ubuntu AS buildliboqs
-# Take in all global args
+
+LABEL version="3"
+
+ENV DEBIAN_FRONTEND=noninteractive
 ARG LIBOQS_TAG
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
-ARG LIBOQS_BUILD_DEFINES
-ARG MAKE_DEFINES
 ARG SIG_ALG
 
-LABEL version="2"
-ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential clang libtool make gcc \
+    ninja-build cmake libtool wget git ca-certificates && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt upgrade -y
-
-# Get all software packages required for builing liboqs:
-RUN apt install -y build-essential clang libtool make gcc ninja-build cmake libtool wget git
-
-# Get OpenSSL image (from cache)
+# Copy the previously built OpenSSL installation from the buildopenssl stage.
 COPY --from=buildopenssl ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch ${LIBOQS_TAG} https://github.com/open-quantum-safe/liboqs
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch ${LIBOQS_TAG} https://github.com/open-quantum-safe/liboqs
 
-WORKDIR /optbuild/liboqs
-RUN mkdir build && \
-    cd build && \
-    cmake -G"Ninja" .. -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} ${LIBOQS_BUILD_DEFINES} -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && \
+# Build and install liboqs
+WORKDIR /optbuild/liboqs/build
+RUN cmake -G"Ninja" .. \
+    -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} \
+    -DCMAKE_INSTALL_PREFIX=${INSTALLDIR_LIBOQS} && \
     ninja install
 
+# Stage 3: Build OQS Provider for OpenSSL
 FROM ubuntu AS buildoqsprovider
-# Take in all global args
 ARG OQSPROVIDER_TAG
 ARG INSTALLDIR_OPENSSL
 ARG INSTALLDIR_LIBOQS
-ARG LIBOQS_BUILD_DEFINES
-ARG MAKE_DEFINES
 ARG SIG_ALG
 
-LABEL version="2"
-ENV DEBIAN_FRONTEND noninteractive
+LABEL version="3"
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt upgrade -y
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential clang libtool make gcc  \
+    ninja-build cmake wget git python3 python3-pip python3-venv && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Get all software packages required for builing oqsprovider
-RUN apt install -y build-essential clang libtool make gcc ninja-build cmake wget git python3 python3-pip && pip3 install jinja2 tabulate
+RUN python3 -m venv /opt/venv
+RUN /opt/venv/bin/pip install --no-cache-dir jinja2 tabulate pyyaml
 
-RUN mkdir /optbuild && cd /optbuild && git clone --depth 1 --branch ${OQSPROVIDER_TAG} https://github.com/open-quantum-safe/oqs-provider.git
+# Set the virtual environment's Python and pip as default
+ENV PATH="/opt/venv/bin:$PATH"
 
-# Get openssl32 and liboqs
+WORKDIR /optbuild
+RUN git clone --depth 1 --branch ${OQSPROVIDER_TAG} https://github.com/open-quantum-safe/oqs-provider.git
+
+# Copy the previously built OpenSSL and liboqs installations
 COPY --from=buildopenssl ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 COPY --from=buildliboqs ${INSTALLDIR_LIBOQS} ${INSTALLDIR_LIBOQS}
 COPY --from=buildliboqs /optbuild/liboqs /optbuild/liboqs
 
+# Modify the oqs-provider configuration to enable all cryptographic algorithms
 WORKDIR /optbuild/oqs-provider
-# configure oqs-provider to activate all algorithms
-RUN sed -i "s/false/true/g" oqs-template/generate.yml && LIBOQS_SRC_DIR=/optbuild/liboqs python3 oqs-template/generate.py
+RUN sed -i "s/false/true/g" oqs-template/generate.yml && \
+    LIBOQS_SRC_DIR=/optbuild/liboqs python3 oqs-template/generate.py
 
-# build & install provider (and activate by default)
-RUN liboqs_DIR=${INSTALLDIR_LIBOQS} cmake -DNOPUBKEY_IN_PRIVKEY=ON -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${INSTALLDIR_OPENSSL} -S . -B _build && \
+# Compile, install, and configure the OQS provider, enabling it by default
+RUN liboqs_DIR=${INSTALLDIR_LIBOQS} cmake -DNOPUBKEY_IN_PRIVKEY=ON \
+    -DOPENSSL_ROOT_DIR=${INSTALLDIR_OPENSSL} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH=${INSTALLDIR_OPENSSL} -S . -B _build && \
     cmake --build _build && \
     cmake --install _build && \
     cp _build/lib/oqsprovider.so ${INSTALLDIR_OPENSSL}/lib64/ossl-modules && \
@@ -114,35 +111,36 @@ RUN liboqs_DIR=${INSTALLDIR_LIBOQS} cmake -DNOPUBKEY_IN_PRIVKEY=ON -DOPENSSL_ROO
     sed -i "s/providers = provider_sect/providers = provider_sect\nssl_conf = ssl_sect\n\n\[ssl_sect\]\nsystem_default = system_default_sect\n\n\[system_default_sect\]\nGroups = \$ENV\:\:DEFAULT_GROUPS\n/g" ${INSTALLDIR_OPENSSL}/ssl/openssl.cnf && \
     sed -i "s/HOME\t\t\t= ./HOME           = .\nDEFAULT_GROUPS = kyber768/g" ${INSTALLDIR_OPENSSL}/ssl/openssl.cnf
 
+# Update the PATH to prioritize the newly installed OpenSSL binaries
 WORKDIR ${INSTALLDIR_OPENSSL}/bin
-# set path to use 'new' openssl. Dyn libs have been properly linked in to match
 ENV PATH="${INSTALLDIR_OPENSSL}/bin:${PATH}"
 
-# generate CA key and cert
+# Create a self-signed CA key and certificate
 RUN set -x; \
     openssl req -x509 -new -newkey ${SIG_ALG} -keyout CA.key -out CA.crt -nodes -subj "/CN=oqstest CA" -days 365
 
-## second stage: Only create minimal image without build tooling and intermediate build results generated above:
+
+# Stage 4: Create a Minimal Runtime Image
 FROM ubuntu AS dev
-# Take in all global args
 ARG INSTALLDIR_OPENSSL
 ARG SIG_ALG
 
-# Only retain the ${INSTALLDIR_OPENSSL} contents in the final image
+# Final stage: Copy only the OpenSSL installation directory from the previous stage
 COPY --from=buildoqsprovider ${INSTALLDIR_OPENSSL} ${INSTALLDIR_OPENSSL}
 
-# set path to use 'new' openssl. Dyn libs have been properly linked in to match
+# Update the PATH to include the new OpenSSL binary directory
 ENV PATH="${INSTALLDIR_OPENSSL}/bin:${PATH}"
 
-# generate certificates for openssl s_server, which is what we will test curl against
+# Generate certificates for the OpenSSL server
 WORKDIR ${INSTALLDIR_OPENSSL}/bin
 
-# generate server CSR using pre-set CA.key and cert
-# and generate server cert
+# Create a certificate signing request (CSR) for the server and sign it using the pre-generated CA
 RUN set -x && mkdir -p /opt/test; \
-    openssl version && openssl list -providers && openssl req -new -newkey ${SIG_ALG} -keyout /opt/test/server.key -out /opt/test/server.csr -nodes -subj "/CN=localhost" && \
+    openssl version && openssl list -providers && \
+    openssl req -new -newkey ${SIG_ALG} -keyout /opt/test/server.key -out /opt/test/server.csr -nodes -subj "/CN=localhost" && \
     openssl x509 -req -in /opt/test/server.csr -out /opt/test/server.crt -CA CA.crt -CAkey CA.key -CAcreateserial -days 365;
 
+# Copy the startup script into the OpenSSL binary directory
 COPY serverstart.sh ${INSTALLDIR_OPENSSL}/bin/serverstart.sh
 
 WORKDIR ${INSTALLDIR_OPENSSL}
@@ -152,9 +150,15 @@ ARG INSTALLDIR_OPENSSL
 
 WORKDIR /
 
-# Enable a normal user to create new server keys off set CA
-RUN groupadd -g 1000 oqs && useradd -u 1000 -g oqs -d /home/oqs oqs && chown -R oqs.oqs /opt/test && chmod go+r ${INSTALLDIR_OPENSSL}/bin/CA.key 
+# Create user 'oqs'
+RUN groupadd oqs && \
+    useradd -m -d /home/oqs -s /bin/bash -g oqs oqs && \
+    mkdir -p /home/oqs && \
+    chown -R oqs:oqs /opt/test && \
+    chmod go+r ${INSTALLDIR_OPENSSL}/bin/CA.key
 
-#USER oqs
+# Set 'oqs' as the default user
+USER oqs
+
 CMD ["serverstart.sh"]
 STOPSIGNAL SIGTERM

--- a/openssl3/fulltest/testrun.sh
+++ b/openssl3/fulltest/testrun.sh
@@ -1,21 +1,48 @@
 #!/bin/bash
+set -e
 
-# Arg1 is docker image to use as client
+# Check if Docker image name is provided
 if [ "$#" -ne 1 ]; then
-    echo "Usage: ${0} <docker-image name>. Exiting."
+    echo "Error: Missing Docker image name."
+    echo "Please provide the name of the Docker image to test."
+    echo "You can check your available images using: docker images"
+    echo "Usage: ${0} <docker-image-name>"
     exit 1
 fi
 
-# prepare test
-rm -rf ca assignments.json* 
-mkdir ca
-# pull current CA cert
-cd ca
-wget https://test.openquantumsafe.org/CA.crt
+DOCKER_IMAGE=$1
+TEST_DIR=$(mktemp -d)
+
+echo "Using test directory: $TEST_DIR"
+
+# Ensure required tools are installed
+if ! command -v wget &> /dev/null; then
+    echo "Error: 'wget' is not installed. Please install it and try again."
+    exit 1
+fi
+
+if ! command -v python3 &> /dev/null; then
+    echo "Error: 'python3' is not installed. Please install it and try again."
+    exit 1
+fi
+
+mkdir -p "$TEST_DIR/ca"
+cd "$TEST_DIR/ca"
+
+echo "Downloading CA certificate..."
+if ! wget -q https://test.openquantumsafe.org/CA.crt; then
+    echo "Error: Failed to download CA.crt"
+    exit 1
+fi
 cd ..
 
-# pull list of algs/ports
-wget https://test.openquantumsafe.org/assignments.json
+echo "Downloading assignments.json..."
+if ! wget -q https://test.openquantumsafe.org/assignments.json; then
+    echo "Error: Failed to download assignments.json"
+    exit 1
+fi
 
-# execute test
-python3 testrun.py ${1}
+echo "Running tests with Docker image: $DOCKER_IMAGE"
+python3 testrun.py "$DOCKER_IMAGE"
+
+echo "Test run completed successfully."


### PR DESCRIPTION
This PR updates the Dockerfile while preserving the existing structure, which uses separate build stages for OpenSSL, liboqs, and oqs-provider. The current structure has been retained to maintain consistency with the original Dockerfile. However, if the team’s intention is to reduce redundancy and merge these stages for a more streamlined build process, I can address this in a future PR.