### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-* @baentsch @ajbozarth
-/.github/ @ajbozarth
-/chromium @pi-314159
-/curl @baentsch @pi-314159
-/httpd @baentsch
-/nginx @baentsch @bhess @pi-314159
+* @baentsch @SWilson4

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+* @baentsch @ajbozarth
+/.github/ @ajbozarth
+/chromium @pi-314159
+/curl @baentsch @pi-314159
+/httpd @baentsch
+/nginx @baentsch @bhess @pi-314159


### PR DESCRIPTION
EDIT: Description out of date, please see https://github.com/open-quantum-safe/oqs-demos/pull/351#issuecomment-2682886307.

Fixes #350.

This is my initial stab at defining CODEOWNERS for the purposes of automatic review requests. It includes
- @baentsch and @ajbozarth for all code, as the people who are most familiar with the project structure.
- @ajbozarth for the CI files.
- @baentsch, @bhess, and @pi-314159 for demos assigned to them in the README.

I haven't included all demos "maintainers" (per the README), only those who currently have write permissions on an OQS repo.

The file is currently invalid because @pi-314159 and @ajbozarth don't have write permissions on the repository. As both have made sizeable contributions to this repo, I propose that we give them write permissions, i.e., elevate them to "codeowner" status for oqs-demos. If there are no objections, I'll create a PR on the tsc repo to add them to the appropriate team.