### PR TITLE
Correct an issue with launching the epiphany container

### DIFF
--- a/epiphany/USAGE.md
+++ b/epiphany/USAGE.md
@@ -10,7 +10,7 @@ The image is based on Ubuntu and requires the host to run the Unix X-Window syst
 
 Execute this command to open the epiphany browser window on your host:
 
-    docker run -it --rm --entrypoint /bin/bash -e DISPLAY=$DISPLAY --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix  openquantumsafe/epiphany
+    docker run --rm -e DISPLAY=$DISPLAY --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix  openquantumsafe/epiphany
 
 *Note*: You may need to grant permissions for Docker to access the X display. As most users run docker in root mode, you would need:
 


### PR DESCRIPTION
Unfortunately the -it --entrypoint /bin/bash in the command means you then have to run epiphany yourself by removing these entries the browser will start automatically